### PR TITLE
Allow defining entities as POJO (remove requirement for BaseEntity)

### DIFF
--- a/lib/BaseEntity.ts
+++ b/lib/BaseEntity.ts
@@ -1,8 +1,5 @@
 import { getMetadataStorage } from './MikroORM';
-import { ObjectID } from 'bson';
 import { Collection } from './Collection';
-import { SCALAR_TYPES } from './EntityFactory';
-import { EntityManager } from './EntityManager';
 import { IEntity } from './decorators/Entity';
 
 export abstract class BaseEntity {
@@ -17,96 +14,6 @@ export abstract class BaseEntity {
         this[prop] = new Collection(this as unknown as IEntity, props[prop], []);
       }
     });
-  }
-
-  assign(data: any, em: EntityManager = null) {
-    const metadata = getMetadataStorage();
-    const meta = metadata[this.constructor.name];
-    const props = meta.properties;
-
-    Object.keys(data).forEach(prop => {
-      if (props[prop] && props[prop].reference === ReferenceType.MANY_TO_ONE && data[prop]) {
-        if (data[prop] instanceof BaseEntity) {
-          return this[prop] = data[prop];
-        }
-
-        if (data[prop] instanceof ObjectID) {
-          return this[prop] = this.getEntityManager(em).getReference(props[prop].type, data[prop].toHexString());
-        }
-
-        const id = typeof data[prop] === 'object' ? data[prop].id : data[prop];
-
-        if (id) {
-          return this[prop] = this.getEntityManager(em).getReference(props[prop].type, id);
-        }
-      }
-
-      const isCollection = props[prop] && [ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference);
-
-      if (isCollection && Array.isArray(data[prop])) {
-        const items = data[prop].map((item: any) => {
-          if (item instanceof ObjectID) {
-            return this.getEntityManager(em).getReference(props[prop].type, item.toHexString());
-          }
-
-          if (item instanceof BaseEntity) {
-            return item;
-          }
-
-          return this.getEntityManager(em).getReference(props[prop].type, item);
-        });
-
-        return (this[prop] as Collection<IEntity>).set(items);
-      }
-
-      if (props[prop] && props[prop].reference === ReferenceType.SCALAR && SCALAR_TYPES.includes(props[prop].type)) {
-        this[prop] = this.getEntityManager(em).validator.validateProperty(props[prop], data[prop], this)
-      }
-
-      this[prop] = data[prop];
-    });
-  }
-
-  toObject(parent: IEntity = this as unknown as IEntity, collection: Collection<IEntity> = null): any {
-    const ret = { id: this.id } as any;
-
-    if (!this.isInitialized()) {
-      return ret;
-    }
-
-    Object.keys(this).forEach(prop => {
-      if (prop === 'id' || prop.startsWith('_')) {
-        return;
-      }
-
-      if (this[prop] instanceof Collection) {
-        const col = this[prop] as Collection<IEntity>;
-
-        if (col.isInitialized(true) && col.shouldPopulate()) {
-          ret[prop] = col.toArray(this as unknown as IEntity);
-        } else if (col.isInitialized() && !col.shouldPopulate()) {
-          ret[prop] = col.getIdentifiers();
-        }
-
-        return;
-      }
-
-      if (this[prop] instanceof BaseEntity) {
-        if (this[prop].isInitialized() && this[prop].shouldPopulate(collection) && this[prop] !== parent) {
-          return ret[prop] = (this[prop] as BaseEntity).toObject(this as unknown as IEntity);
-        }
-
-        return ret[prop] = this[prop].id;
-      }
-
-      ret[prop] = this[prop];
-    });
-
-    return ret;
-  }
-
-  toJSON(): any {
-    return this.toObject();
   }
 
 }

--- a/lib/BaseEntity.ts
+++ b/lib/BaseEntity.ts
@@ -11,7 +11,7 @@ export abstract class BaseEntity {
 
     Object.keys(props).forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference)) {
-        this[prop] = new Collection(this, prop, []);
+        this[prop] = new Collection(this);
       }
     });
   }

--- a/lib/BaseEntity.ts
+++ b/lib/BaseEntity.ts
@@ -11,7 +11,7 @@ export abstract class BaseEntity {
 
     Object.keys(props).forEach(prop => {
       if ([ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference)) {
-        this[prop] = new Collection(this as unknown as IEntity, props[prop], []);
+        this[prop] = new Collection(this, prop, []);
       }
     });
   }

--- a/lib/BaseEntity.ts
+++ b/lib/BaseEntity.ts
@@ -1,6 +1,6 @@
 import { getMetadataStorage } from './MikroORM';
 import { Collection } from './Collection';
-import { IEntity } from './decorators/Entity';
+import { IEntity, ReferenceType } from './decorators/Entity';
 
 export abstract class BaseEntity {
 
@@ -16,41 +16,6 @@ export abstract class BaseEntity {
     });
   }
 
-}
-
-export enum ReferenceType {
-  SCALAR = 0,
-  MANY_TO_ONE = 1,
-  ONE_TO_MANY = 2,
-  MANY_TO_MANY = 3,
-}
-
-export interface EntityProperty {
-  name: string;
-  fk: string;
-  entity: () => string | Function;
-  type: string;
-  reference: ReferenceType;
-  fieldName?: string;
-  attributes?: { [attribute: string]: any };
-  onUpdate?: () => any;
-  owner?: boolean;
-  inversedBy?: string;
-  mappedBy?: string;
-  pivotTable?: string;
-  joinColumn?: string;
-  inverseJoinColumn?: string;
-  referenceColumnName?: string;
-}
-
-export interface EntityMetadata {
-  name: string;
-  constructorParams: string[];
-  collection: string;
-  path: string;
-  properties: { [property: string]: EntityProperty };
-  customRepository: any;
-  hooks: { [type: string]: string[] };
 }
 
 export interface BaseEntity extends IEntity { }

--- a/lib/Collection.ts
+++ b/lib/Collection.ts
@@ -13,11 +13,13 @@ export class Collection<T extends IEntity> {
   private _property: EntityProperty;
   private readonly items: T[] = [];
 
-  constructor(readonly owner: IEntity, private readonly propertyName: string, items: T[] = null) {
+  constructor(readonly owner: IEntity, items: T[] = null, initialized = true) {
     if (items) {
       this.initialized = true;
       this.items = items;
       Object.assign(this, items);
+    } else if (initialized) {
+      this.initialized = initialized;
     }
   }
 
@@ -212,7 +214,8 @@ export class Collection<T extends IEntity> {
     if (!this._property) {
       const metadata = getMetadataStorage();
       const meta = metadata[this.owner.constructor.name];
-      this._property = meta.properties[this.propertyName];
+      const field = Object.keys(meta.properties).find(k => this.owner[k] === this);
+      this._property = meta.properties[field];
     }
 
     return this._property;

--- a/lib/Collection.ts
+++ b/lib/Collection.ts
@@ -1,6 +1,5 @@
-import { EntityProperty, ReferenceType } from './BaseEntity';
 import { IPrimaryKey } from './decorators/PrimaryKey';
-import { IEntity } from './decorators/Entity';
+import { EntityProperty, IEntity, ReferenceType } from './decorators/Entity';
 import { getMetadataStorage } from './MikroORM';
 
 export class Collection<T extends IEntity> {

--- a/lib/Collection.ts
+++ b/lib/Collection.ts
@@ -1,7 +1,8 @@
-import { BaseEntity, EntityProperty, ReferenceType } from './BaseEntity';
+import { EntityProperty, ReferenceType } from './BaseEntity';
 import { IPrimaryKey } from './decorators/PrimaryKey';
+import { IEntity } from './decorators/Entity';
 
-export class Collection<T extends BaseEntity> {
+export class Collection<T extends IEntity> {
 
   [k: number]: T;
 
@@ -10,7 +11,7 @@ export class Collection<T extends BaseEntity> {
   private _populated = false;
   private readonly items: T[] = [];
 
-  constructor(readonly owner: BaseEntity,
+  constructor(readonly owner: IEntity,
               private readonly property: EntityProperty,
               items: T[] = null) {
     if (items) {
@@ -64,7 +65,7 @@ export class Collection<T extends BaseEntity> {
 
     // re-order items when searching with `$in` operator
     if (this.property.reference === ReferenceType.MANY_TO_MANY && this.property.owner) {
-      items.sort((a: BaseEntity, b: BaseEntity) => {
+      items.sort((a: IEntity, b: IEntity) => {
         return order.indexOf(a.id) - order.indexOf(b.id);
       });
     }
@@ -84,7 +85,7 @@ export class Collection<T extends BaseEntity> {
     return [...this.items];
   }
 
-  toArray(parent: BaseEntity = this.owner): any[] {
+  toArray(parent: IEntity = this.owner): any[] {
     return this.getItems().map(item => item.toObject(parent, this));
   }
 

--- a/lib/Collection.ts
+++ b/lib/Collection.ts
@@ -1,6 +1,7 @@
 import { EntityProperty, ReferenceType } from './BaseEntity';
 import { IPrimaryKey } from './decorators/PrimaryKey';
 import { IEntity } from './decorators/Entity';
+import { getMetadataStorage } from './MikroORM';
 
 export class Collection<T extends IEntity> {
 
@@ -9,11 +10,10 @@ export class Collection<T extends IEntity> {
   private initialized = false;
   private dirty = false;
   private _populated = false;
+  private _property: EntityProperty;
   private readonly items: T[] = [];
 
-  constructor(readonly owner: IEntity,
-              private readonly property: EntityProperty,
-              items: T[] = null) {
+  constructor(readonly owner: IEntity, private readonly propertyName: string, items: T[] = null) {
     if (items) {
       this.initialized = true;
       this.items = items;
@@ -206,6 +206,16 @@ export class Collection<T extends IEntity> {
     }
 
     items.forEach(item => this.items.push(em.entityFactory.createReference(this.property.type, item[fk2])));
+  }
+
+  private get property() {
+    if (!this._property) {
+      const metadata = getMetadataStorage();
+      const meta = metadata[this.owner.constructor.name];
+      this._property = meta.properties[this.propertyName];
+    }
+
+    return this._property;
   }
 
 }

--- a/lib/Collection.ts
+++ b/lib/Collection.ts
@@ -209,4 +209,3 @@ export class Collection<T extends IEntity> {
   }
 
 }
-

--- a/lib/EntityFactory.ts
+++ b/lib/EntityFactory.ts
@@ -4,9 +4,8 @@ import Project, { SourceFile } from 'ts-simple-ast';
 import { getMetadataStorage, MikroORMOptions } from './MikroORM';
 import { Collection } from './Collection';
 import { EntityManager } from './EntityManager';
-import { EntityMetadata, EntityProperty, ReferenceType } from './BaseEntity';
 import { IPrimaryKey } from './decorators/PrimaryKey';
-import { IEntity } from './decorators/Entity';
+import { EntityMetadata, EntityProperty, IEntity, ReferenceType } from './decorators/Entity';
 import { Utils } from './Utils';
 
 export const SCALAR_TYPES = ['string', 'number', 'boolean', 'Date'];

--- a/lib/EntityFactory.ts
+++ b/lib/EntityFactory.ts
@@ -86,17 +86,17 @@ export class EntityFactory {
       const prop = properties[p] as EntityProperty;
 
       if (prop.reference === ReferenceType.ONE_TO_MANY && !data[p]) {
-        return entity[p] = new Collection<T>(entity, prop.name);
+        return entity[p] = new Collection<T>(entity, null, false);
       }
 
       if (prop.reference === ReferenceType.MANY_TO_MANY) {
         if (prop.owner && Array.isArray(data[p])) {
           const driver = this.em.getDriver();
           const items = data[p].map((id: IPrimaryKey) => this.createReference(prop.type, driver.normalizePrimaryKey(id)));
-          return entity[p] = new Collection<T>(entity, prop.name, items);
+          return entity[p] = new Collection<T>(entity, items, false);
         } else if (!entity[p]) {
           const items = prop.owner && !this.em.getDriver().usesPivotTable() ? [] : null;
-          return entity[p] = new Collection<T>(entity, prop.name, items);
+          return entity[p] = new Collection<T>(entity, items, false);
         }
       }
 

--- a/lib/EntityHelper.ts
+++ b/lib/EntityHelper.ts
@@ -3,7 +3,8 @@ import { Collection } from './Collection';
 import { SCALAR_TYPES } from './EntityFactory';
 import { EntityManager } from './EntityManager';
 import { IEntity } from './decorators/Entity';
-import { BaseEntity, ReferenceType } from './BaseEntity';
+import { ReferenceType } from './BaseEntity';
+import { Utils } from './Utils';
 
 export class EntityHelper {
 
@@ -17,7 +18,7 @@ export class EntityHelper {
 
     Object.keys(data).forEach(prop => {
       if (props[prop] && props[prop].reference === ReferenceType.MANY_TO_ONE && data[prop]) {
-        if (data[prop] instanceof BaseEntity) {
+        if (Utils.isEntity(data[prop])) {
           return this.entity[prop] = data[prop];
         }
 
@@ -40,7 +41,7 @@ export class EntityHelper {
             return em.getReference(props[prop].type, item.toHexString());
           }
 
-          if (item instanceof BaseEntity) {
+          if (Utils.isEntity(item)) {
             return item;
           }
 
@@ -75,7 +76,7 @@ export class EntityHelper {
         const col = this.entity[prop] as Collection<IEntity>;
 
         if (col.isInitialized(true) && col.shouldPopulate()) {
-          ret[prop] = col.toArray(this.entity as unknown as IEntity);
+          ret[prop] = col.toArray(this.entity);
         } else if (col.isInitialized() && !col.shouldPopulate()) {
           ret[prop] = col.getIdentifiers();
         }
@@ -83,9 +84,9 @@ export class EntityHelper {
         return;
       }
 
-      if (this.entity[prop] instanceof BaseEntity) {
+      if (Utils.isEntity(this.entity[prop])) {
         if (this.entity[prop].isInitialized() && this.entity[prop].shouldPopulate(collection) && this.entity[prop] !== parent) {
-          return ret[prop] = (this.entity[prop] as BaseEntity).toObject(this.entity as unknown as IEntity);
+          return ret[prop] = (this.entity[prop] as IEntity).toObject(this.entity);
         }
 
         return ret[prop] = this.entity[prop].id;

--- a/lib/EntityHelper.ts
+++ b/lib/EntityHelper.ts
@@ -1,0 +1,100 @@
+import { ObjectID } from 'bson';
+import { Collection } from './Collection';
+import { SCALAR_TYPES } from './EntityFactory';
+import { EntityManager } from './EntityManager';
+import { IEntity } from './decorators/Entity';
+import { BaseEntity, ReferenceType } from './BaseEntity';
+
+export class EntityHelper {
+
+  constructor(private readonly entity: IEntity) { }
+
+  assign(data: any, em: EntityManager = null) {
+    em = this.entity.getEntityManager(em);
+    const metadata = em.entityFactory.getMetadata();
+    const meta = metadata[this.entity.constructor.name];
+    const props = meta.properties;
+
+    Object.keys(data).forEach(prop => {
+      if (props[prop] && props[prop].reference === ReferenceType.MANY_TO_ONE && data[prop]) {
+        if (data[prop] instanceof BaseEntity) {
+          return this.entity[prop] = data[prop];
+        }
+
+        if (data[prop] instanceof ObjectID) {
+          return this.entity[prop] = em.getReference(props[prop].type, data[prop].toHexString());
+        }
+
+        const id = typeof data[prop] === 'object' ? data[prop].id : data[prop];
+
+        if (id) {
+          return this.entity[prop] = em.getReference(props[prop].type, id);
+        }
+      }
+
+      const isCollection = props[prop] && [ReferenceType.ONE_TO_MANY, ReferenceType.MANY_TO_MANY].includes(props[prop].reference);
+
+      if (isCollection && Array.isArray(data[prop])) {
+        const items = data[prop].map((item: any) => {
+          if (item instanceof ObjectID) {
+            return em.getReference(props[prop].type, item.toHexString());
+          }
+
+          if (item instanceof BaseEntity) {
+            return item;
+          }
+
+          return em.getReference(props[prop].type, item);
+        });
+
+        return (this.entity[prop] as Collection<IEntity>).set(items);
+      }
+
+      if (props[prop] && props[prop].reference === ReferenceType.SCALAR && SCALAR_TYPES.includes(props[prop].type)) {
+        this.entity[prop] = em.validator.validateProperty(props[prop], data[prop], this.entity)
+      }
+
+      this.entity[prop] = data[prop];
+    });
+  }
+
+  toObject(parent?: IEntity, collection: Collection<IEntity> = null): any {
+    parent = parent || this.entity;
+    const ret = { id: this.entity.id } as any;
+
+    if (!this.entity.isInitialized()) {
+      return ret;
+    }
+
+    Object.keys(this.entity).forEach(prop => {
+      if (prop === 'id' || prop.startsWith('_')) {
+        return;
+      }
+
+      if (this.entity[prop] instanceof Collection) {
+        const col = this.entity[prop] as Collection<IEntity>;
+
+        if (col.isInitialized(true) && col.shouldPopulate()) {
+          ret[prop] = col.toArray(this.entity as unknown as IEntity);
+        } else if (col.isInitialized() && !col.shouldPopulate()) {
+          ret[prop] = col.getIdentifiers();
+        }
+
+        return;
+      }
+
+      if (this.entity[prop] instanceof BaseEntity) {
+        if (this.entity[prop].isInitialized() && this.entity[prop].shouldPopulate(collection) && this.entity[prop] !== parent) {
+          return ret[prop] = (this.entity[prop] as BaseEntity).toObject(this.entity as unknown as IEntity);
+        }
+
+        return ret[prop] = this.entity[prop].id;
+      }
+
+      ret[prop] = this.entity[prop];
+    });
+
+    return ret;
+  }
+
+}

--- a/lib/EntityHelper.ts
+++ b/lib/EntityHelper.ts
@@ -61,9 +61,9 @@ export class EntityHelper {
 
   toObject(parent?: IEntity, collection: Collection<IEntity> = null): any {
     parent = parent || this.entity;
-    const ret = { id: this.entity.id } as any;
+    const ret = this.entity.id ? { id: this.entity.id } : {} as any;
 
-    if (!this.entity.isInitialized()) {
+    if (!this.entity.isInitialized() && this.entity.id) {
       return ret;
     }
 

--- a/lib/EntityHelper.ts
+++ b/lib/EntityHelper.ts
@@ -1,13 +1,39 @@
 import { Collection } from './Collection';
 import { SCALAR_TYPES } from './EntityFactory';
 import { EntityManager } from './EntityManager';
-import { IEntity } from './decorators/Entity';
-import { EntityProperty, ReferenceType } from './BaseEntity';
+import { EntityProperty, IEntity, ReferenceType } from './decorators/Entity';
 import { Utils } from './Utils';
 
 export class EntityHelper {
 
   constructor(private readonly entity: IEntity) { }
+
+  async init(populated = true, em: EntityManager = null): Promise<IEntity> {
+    await (em || this.entity.getEntityManager(em)).findOne(this.entity.constructor.name, this.entity.id);
+    this.entity.populated(populated);
+
+    return this.entity;
+  }
+
+  setEntityManager(em: EntityManager): void {
+    Object.defineProperty(this.entity, '_em', {
+      value: em,
+      enumerable: false,
+      writable: true,
+    });
+  }
+
+  getEntityManager(em: EntityManager = null): EntityManager {
+    if (em) {
+      this.entity._em = em;
+    }
+
+    if (!this.entity._em) {
+      throw new Error('This entity is not attached to EntityManager, please provide one!');
+    }
+
+    return this.entity._em;
+  }
 
   assign(data: any, em: EntityManager = null) {
     em = this.entity.getEntityManager(em);

--- a/lib/EntityManager.ts
+++ b/lib/EntityManager.ts
@@ -110,7 +110,7 @@ export class EntityManager {
       throw new Error(`You cannot call 'EntityManager.findOne()' with empty 'where' parameter`);
     }
 
-    where = this.driver.normalizePrimaryKey(where);
+    where = this.driver.normalizePrimaryKey(where as IPrimaryKey);
 
     if (Utils.isPrimaryKey(where) && this.getIdentity(entityName, where) && this.getIdentity(entityName, where).isInitialized()) {
       await this.populateOne(entityName, this.getIdentity(entityName, where), populate);

--- a/lib/EntityManager.ts
+++ b/lib/EntityManager.ts
@@ -1,4 +1,3 @@
-import { EntityMetadata, ReferenceType } from './BaseEntity';
 import { EntityRepository } from './EntityRepository';
 import { EntityFactory } from './EntityFactory';
 import { UnitOfWork } from './UnitOfWork';
@@ -12,7 +11,7 @@ import { IDatabaseDriver } from './drivers/IDatabaseDriver';
 import { IPrimaryKey } from './decorators/PrimaryKey';
 import { QueryBuilder } from './QueryBuilder';
 import { NamingStrategy } from './naming-strategy/NamingStrategy';
-import { IEntity } from './decorators/Entity';
+import { EntityMetadata, IEntity, ReferenceType } from './decorators/Entity';
 
 export class EntityManager {
 

--- a/lib/EntityRepository.ts
+++ b/lib/EntityRepository.ts
@@ -1,10 +1,10 @@
 import { EntityManager } from './EntityManager';
-import { BaseEntity } from './BaseEntity';
 import { RequestContext } from './RequestContext';
 import { FilterQuery } from './drivers/DatabaseDriver';
 import { IPrimaryKey } from './decorators/PrimaryKey';
+import { IEntity } from './decorators/Entity';
 
-export class EntityRepository<T extends BaseEntity> {
+export class EntityRepository<T extends IEntity> {
 
   constructor(private _em: EntityManager,
               protected entityName: string) { }
@@ -52,7 +52,7 @@ export class EntityRepository<T extends BaseEntity> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<T extends BaseEntity>(id: IPrimaryKey): T {
+  getReference<T extends IEntity>(id: IPrimaryKey): T {
     return this.em.getReference<T>(this.entityName, id);
   }
 

--- a/lib/MikroORM.ts
+++ b/lib/MikroORM.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 
 import { EntityManager } from './EntityManager';
-import { EntityMetadata } from './BaseEntity';
+import { EntityMetadata } from './decorators/Entity';
 import { MongoDriver } from './drivers/MongoDriver';
 import { IDatabaseDriver } from './drivers/IDatabaseDriver';
 import { NamingStrategy } from './naming-strategy/NamingStrategy';

--- a/lib/QueryBuilder.ts
+++ b/lib/QueryBuilder.ts
@@ -1,5 +1,5 @@
 import { Utils } from './Utils';
-import { EntityMetadata, ReferenceType } from './BaseEntity';
+import { EntityMetadata, ReferenceType } from './decorators/Entity';
 
 /**
  * MySQL query builder

--- a/lib/UnitOfWork.ts
+++ b/lib/UnitOfWork.ts
@@ -1,6 +1,7 @@
 import { Utils } from './Utils';
 import { EntityManager } from './EntityManager';
 import { BaseEntity, EntityMetadata, EntityProperty, ReferenceType } from './BaseEntity';
+import { IEntity } from './decorators/Entity';
 
 export class UnitOfWork {
 
@@ -11,11 +12,11 @@ export class UnitOfWork {
 
   constructor(private em: EntityManager) { }
 
-  addToIdentityMap(entity: BaseEntity): void {
+  addToIdentityMap(entity: IEntity): void {
     this.identityMap[`${entity.constructor.name}-${entity.id}`] = Utils.copy(entity);
   }
 
-  async persist(entity: BaseEntity): Promise<ChangeSet> {
+  async persist(entity: IEntity): Promise<ChangeSet> {
     const changeSet = await this.computeChangeSet(entity);
 
     if (!changeSet) {
@@ -40,11 +41,11 @@ export class UnitOfWork {
     Object.keys(this.identityMap).forEach(key => delete this.identityMap[key]);
   }
 
-  remove(entity: BaseEntity): void {
+  remove(entity: IEntity): void {
     delete this.identityMap[`${entity.constructor.name}-${entity.id}`];
   }
 
-  private async computeChangeSet(entity: BaseEntity): Promise<ChangeSet> {
+  private async computeChangeSet(entity: IEntity): Promise<ChangeSet> {
     const ret = { entity } as ChangeSet;
     const metadata = this.em.entityFactory.getMetadata();
     const meta = metadata[entity.constructor.name];
@@ -95,6 +96,7 @@ export class UnitOfWork {
       await this.immediateCommit(propChangeSet);
     }
 
+    // FIXME find a way to check for base entity without the base class itself
     if (changeSet.payload[prop.name] instanceof BaseEntity) {
       changeSet.payload[prop.name] = changeSet.entity[prop.name][this.foreignKey];
     }
@@ -189,7 +191,7 @@ export class UnitOfWork {
     }
   }
 
-  private runHooks(type: string, entity: BaseEntity, payload: any = null) {
+  private runHooks(type: string, entity: IEntity, payload: any = null) {
     const metadata = this.em.entityFactory.getMetadata();
     const hooks = metadata[entity.constructor.name].hooks;
 
@@ -210,5 +212,5 @@ export interface ChangeSet {
   payload: any;
   collection: string;
   name: string;
-  entity: BaseEntity;
+  entity: IEntity;
 }

--- a/lib/UnitOfWork.ts
+++ b/lib/UnitOfWork.ts
@@ -1,7 +1,6 @@
 import { Utils } from './Utils';
 import { EntityManager } from './EntityManager';
-import { EntityMetadata, EntityProperty, ReferenceType } from './BaseEntity';
-import { IEntity } from './decorators/Entity';
+import { EntityMetadata, EntityProperty, IEntity, ReferenceType } from './decorators/Entity';
 
 export class UnitOfWork {
 

--- a/lib/UnitOfWork.ts
+++ b/lib/UnitOfWork.ts
@@ -53,7 +53,7 @@ export class UnitOfWork {
     ret.collection = meta.collection;
 
     if (entity.id && this.identityMap[`${meta.name}-${entity.id}`]) {
-      ret.payload = Utils.diffEntities(this.identityMap[`${meta.name}-${entity.id}`], entity);
+      ret.payload = Utils.diffEntities(this.identityMap[`${meta.name}-${entity.id}`], entity, this.em.getDriver());
     } else {
       ret.payload = Object.assign({}, entity); // TODO maybe we need deep copy?
     }
@@ -198,7 +198,7 @@ export class UnitOfWork {
       hooks[type].forEach(hook => entity[hook]());
 
       if (payload) {
-        Object.assign(payload, Utils.diffEntities(copy, entity));
+        Object.assign(payload, Utils.diffEntities(copy, entity, this.em.getDriver()));
       }
     }
   }

--- a/lib/UnitOfWork.ts
+++ b/lib/UnitOfWork.ts
@@ -1,6 +1,6 @@
 import { Utils } from './Utils';
 import { EntityManager } from './EntityManager';
-import { BaseEntity, EntityMetadata, EntityProperty, ReferenceType } from './BaseEntity';
+import { EntityMetadata, EntityProperty, ReferenceType } from './BaseEntity';
 import { IEntity } from './decorators/Entity';
 
 export class UnitOfWork {
@@ -96,8 +96,7 @@ export class UnitOfWork {
       await this.immediateCommit(propChangeSet);
     }
 
-    // FIXME find a way to check for base entity without the base class itself
-    if (changeSet.payload[prop.name] instanceof BaseEntity) {
+    if (Utils.isEntity(changeSet.payload[prop.name])) {
       changeSet.payload[prop.name] = changeSet.entity[prop.name][this.foreignKey];
     }
   }

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -1,7 +1,7 @@
 import * as fastEqual from 'fast-deep-equal';
 import * as clone from 'clone';
 import { IEntity, IPrimaryKey, ObjectID } from '.';
-import { ReferenceType } from './BaseEntity';
+import { ReferenceType } from './decorators/Entity';
 import { Collection } from './Collection';
 import { getMetadataStorage } from './MikroORM';
 
@@ -165,7 +165,7 @@ export class Utils {
   }
 
   static isEntity(data: any): boolean {
-    return Utils.isObject(data) && data.__isEntity;
+    return Utils.isObject(data) && data.__entity;
   }
 
 }

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -1,6 +1,6 @@
 import * as fastEqual from 'fast-deep-equal';
 import * as clone from 'clone';
-import { IEntity, IPrimaryKey, ObjectID } from '.';
+import { IDatabaseDriver, IEntity, IPrimaryKey, ObjectID } from '.';
 import { ReferenceType } from './decorators/Entity';
 import { Collection } from './Collection';
 import { getMetadataStorage } from './MikroORM';
@@ -46,7 +46,7 @@ export class Utils {
   /**
    * Process references first so we do not have to deal with cycles
    */
-  static diffEntities(a: IEntity, b: IEntity): any {
+  static diffEntities(a: IEntity, b: IEntity, driver: IDatabaseDriver): any {
     const diff = Utils.diff(Utils.prepareEntity(a), Utils.prepareEntity(b));
 
     // convert string ids back to object ids
@@ -54,7 +54,7 @@ export class Utils {
     const meta = metadata[a.constructor.name];
     Object.keys(diff).forEach((prop: string) => {
       if ((meta.properties[prop]).reference === ReferenceType.MANY_TO_ONE) {
-        diff[prop] = new ObjectID(diff[prop]); // FIXME
+        diff[prop] = driver.denormalizePrimaryKey(diff[prop]);
       }
     });
 

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -1,7 +1,7 @@
 import * as fastEqual from 'fast-deep-equal';
 import * as clone from 'clone';
-import { IPrimaryKey, ObjectID } from '.';
-import { BaseEntity, ReferenceType } from './BaseEntity';
+import { BaseEntity, IEntity, IPrimaryKey, ObjectID } from '.';
+import { ReferenceType } from './BaseEntity';
 import { Collection } from './Collection';
 import { getMetadataStorage } from './MikroORM';
 
@@ -58,7 +58,7 @@ export class Utils {
   /**
    * Process references first so we do not have to deal with cycles
    */
-  static diffEntities(a: BaseEntity, b: BaseEntity): any {
+  static diffEntities(a: IEntity, b: IEntity): any {
     const diff = Utils.diff(Utils.prepareEntity(a), Utils.prepareEntity(b));
 
     // convert string ids back to object ids
@@ -73,14 +73,15 @@ export class Utils {
     return diff;
   }
 
-  static prepareEntity(e: BaseEntity): any {
+  static prepareEntity(e: IEntity): any {
     const metadata = getMetadataStorage();
     const meta = metadata[e.constructor.name];
     const ret = Utils.copy(e);
 
+    // FIXME find a way to check for base entity without the base class itself
     // remove collections and references
     Object.keys(meta.properties).forEach(prop => {
-      if (ret[prop] instanceof Collection || (ret[prop] instanceof BaseEntity && !ret[prop]._id)) {
+      if (ret[prop] instanceof Collection || (ret[prop] instanceof BaseEntity && !ret[prop].id)) {
         return delete ret[prop];
       }
 

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -33,20 +33,8 @@ export class Utils {
         return;
       }
 
-      if (a[k] === undefined && b !== undefined) {
-        return ret[k] = b[k];
-      }
-
-      if (a[k] !== undefined && b === undefined) {
-        return ret[k] = a[k];
-      }
-
       if (Utils.equals(a[k], b[k])) {
         return;
-      }
-
-      if (Array.isArray(a[k]) && Array.isArray(b[k])) {
-        return ret[k] = b[k]; // right-hand side has priority
       }
 
       ret[k] = b[k];

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -1,6 +1,6 @@
 import * as fastEqual from 'fast-deep-equal';
 import * as clone from 'clone';
-import { BaseEntity, IEntity, IPrimaryKey, ObjectID } from '.';
+import { IEntity, IPrimaryKey, ObjectID } from '.';
 import { ReferenceType } from './BaseEntity';
 import { Collection } from './Collection';
 import { getMetadataStorage } from './MikroORM';
@@ -78,14 +78,13 @@ export class Utils {
     const meta = metadata[e.constructor.name];
     const ret = Utils.copy(e);
 
-    // FIXME find a way to check for base entity without the base class itself
     // remove collections and references
     Object.keys(meta.properties).forEach(prop => {
-      if (ret[prop] instanceof Collection || (ret[prop] instanceof BaseEntity && !ret[prop].id)) {
+      if (ret[prop] instanceof Collection || (Utils.isEntity(ret[prop]) && !ret[prop].id)) {
         return delete ret[prop];
       }
 
-      if (ret[prop] instanceof BaseEntity) {
+      if (Utils.isEntity(ret[prop])) {
         return ret[prop] = ret[prop].id;
       }
     });
@@ -175,6 +174,10 @@ export class Utils {
     }
 
     return null;
+  }
+
+  static isEntity(data: any): boolean {
+    return Utils.isObject(data) && data.__isEntity;
   }
 
 }

--- a/lib/Validator.ts
+++ b/lib/Validator.ts
@@ -1,6 +1,5 @@
-import { EntityMetadata, EntityProperty, ReferenceType } from './BaseEntity';
 import { SCALAR_TYPES } from './EntityFactory';
-import { IEntity } from './decorators/Entity';
+import { EntityMetadata, EntityProperty, IEntity, ReferenceType } from './decorators/Entity';
 
 export class Validator {
 

--- a/lib/Validator.ts
+++ b/lib/Validator.ts
@@ -1,11 +1,12 @@
-import { BaseEntity, EntityMetadata, EntityProperty, ReferenceType } from './BaseEntity';
+import { EntityMetadata, EntityProperty, ReferenceType } from './BaseEntity';
 import { SCALAR_TYPES } from './EntityFactory';
+import { IEntity } from './decorators/Entity';
 
 export class Validator {
 
   constructor(private strict: boolean) { }
 
-  validate(entity: BaseEntity, payload: any, meta: EntityMetadata): void {
+  validate(entity: IEntity, payload: any, meta: EntityMetadata): void {
     Object.keys(payload).forEach(prop => {
       const property = meta.properties[prop];
 
@@ -17,7 +18,7 @@ export class Validator {
     });
   }
 
-  validateProperty(prop: EntityProperty, givenValue: any, entity: BaseEntity) {
+  validateProperty(prop: EntityProperty, givenValue: any, entity: IEntity) {
     if (givenValue === null) {
       return givenValue;
     }

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -108,7 +108,3 @@ export interface IEntity {
   assign(data: any, em?: EntityManager): void;
   [property: string]: any | IEntity | Collection<IEntity>;
 }
-
-export interface Entity extends IEntity {
-
-}

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -1,6 +1,9 @@
 import { merge } from 'lodash';
 import { getMetadataStorage } from '../MikroORM';
 import { Utils } from '../Utils';
+import { Collection } from '../Collection';
+import { IPrimaryKey } from './PrimaryKey';
+import { EntityManager } from '../EntityManager';
 
 export function Entity(options: EntityOptions = {}): Function {
   return function <T extends { new(...args: any[]): {} }>(target: T) {
@@ -14,6 +17,59 @@ export function Entity(options: EntityOptions = {}): Function {
     meta.name = target.name;
     meta.constructorParams = Utils.getParamNames(target);
 
+    Object.defineProperties(target, {
+      _initialized: { value: false, writable: true, enumerable: false },
+      _populated: { value: false, writable: true, enumerable: false },
+    });
+
+    Object.defineProperties(target.prototype, {
+      isInitialized: {
+        value: function () {
+          return this._initialized !== false;
+        },
+      },
+      shouldPopulate: {
+        value: function (collection: Collection<IEntity> = null) {
+          return this._populated && !collection;
+        },
+      },
+      populated: {
+        value: function (populated = true) {
+          this._populated = populated;
+        },
+      },
+      init: {
+        value: async function (populated = true, em: EntityManager = null): Promise<IEntity> {
+          await (em || this.getEntityManager(em)).findOne(this.constructor.name, this.id);
+          this._populated = populated;
+
+          return this as unknown as IEntity;
+        },
+      },
+      setEntityManager: {
+        value: function (em: EntityManager): void {
+          Object.defineProperty(this, '_em', {
+            value: em,
+            enumerable: false,
+            writable: true,
+          });
+        },
+      },
+      getEntityManager: {
+        value: function (em: EntityManager = null): EntityManager {
+          if (em) {
+            this._em = em;
+          }
+
+          if (!this._em) {
+            throw new Error('This entity is not attached to EntityManager, please provide one!');
+          }
+
+          return this._em;
+        },
+      },
+    });
+
     return target;
   };
 }
@@ -21,4 +77,22 @@ export function Entity(options: EntityOptions = {}): Function {
 export type EntityOptions = {
   collection?: string;
   customRepository?: any;
+}
+
+export interface IEntity {
+  id: IPrimaryKey;
+  isInitialized(): boolean;
+  shouldPopulate(collection?: Collection<IEntity>): boolean;
+  populated(populated?: boolean): void;
+  init(populated?, em?: EntityManager): Promise<IEntity>;
+  setEntityManager(populated: EntityManager): void;
+  getEntityManager(populated?: EntityManager): EntityManager;
+  toJSON(): any;
+  toObject(parent?: IEntity, collection?: Collection<IEntity>): any;
+  assign(data: any, em?: EntityManager): void;
+  [property: string]: any | IEntity | Collection<IEntity>;
+}
+
+export interface Entity extends IEntity {
+
 }

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -4,9 +4,10 @@ import { Utils } from '../Utils';
 import { Collection } from '../Collection';
 import { IPrimaryKey } from './PrimaryKey';
 import { EntityManager } from '../EntityManager';
+import { EntityHelper } from '../EntityHelper';
 
 export function Entity(options: EntityOptions = {}): Function {
-  return function <T extends { new(...args: any[]): {} }>(target: T) {
+  return function <T extends { new(...args: any[]): IEntity }>(target: T) {
     const storage = getMetadataStorage(target.name);
     const meta = storage[target.name];
 
@@ -45,6 +46,21 @@ export function Entity(options: EntityOptions = {}): Function {
 
           return this as unknown as IEntity;
         },
+      },
+      assign: {
+        value: function (data: any, em: EntityManager = null) {
+          new EntityHelper(this).assign(data, em);
+        }
+      },
+      toObject: {
+        value: function (parent?: IEntity, collection: Collection<IEntity> = null) {
+          return new EntityHelper(this).toObject(parent, collection);
+        }
+      },
+      toJSON: {
+        value: function () {
+          return new EntityHelper(this).toObject();
+        }
       },
       setEntityManager: {
         value: function (em: EntityManager): void {
@@ -85,8 +101,8 @@ export interface IEntity {
   shouldPopulate(collection?: Collection<IEntity>): boolean;
   populated(populated?: boolean): void;
   init(populated?, em?: EntityManager): Promise<IEntity>;
-  setEntityManager(populated: EntityManager): void;
-  getEntityManager(populated?: EntityManager): EntityManager;
+  setEntityManager(em: EntityManager): void;
+  getEntityManager(em?: EntityManager): EntityManager;
   toJSON(): any;
   toObject(parent?: IEntity, collection?: Collection<IEntity>): any;
   assign(data: any, em?: EntityManager): void;

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -18,9 +18,9 @@ export function Entity(options: EntityOptions = {}): Function {
     meta.name = target.name;
     meta.constructorParams = Utils.getParamNames(target);
 
-    Object.defineProperties(target, {
-      _initialized: { value: false, writable: true, enumerable: false },
-      _populated: { value: false, writable: true, enumerable: false },
+    Object.defineProperties(target.prototype, {
+      _populated: { value: false, writable: true, enumerable: false, configurable: false },
+      __isEntity: { value: true, writable: false, enumerable: false, configurable: false },
     });
 
     Object.defineProperties(target.prototype, {
@@ -44,7 +44,7 @@ export function Entity(options: EntityOptions = {}): Function {
           await (em || this.getEntityManager(em)).findOne(this.constructor.name, this.id);
           this._populated = populated;
 
-          return this as unknown as IEntity;
+          return this;
         },
       },
       assign: {

--- a/lib/decorators/ManyToMany.ts
+++ b/lib/decorators/ManyToMany.ts
@@ -1,7 +1,6 @@
-import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
 import { PropertyOptions } from './Property';
-import { IEntity } from './Entity';
+import { EntityProperty, IEntity, ReferenceType } from './Entity';
 
 export function ManyToMany(options: ManyToManyOptions): Function {
   return function (target: IEntity, propertyName: string) {

--- a/lib/decorators/ManyToMany.ts
+++ b/lib/decorators/ManyToMany.ts
@@ -1,9 +1,10 @@
-import { BaseEntity, EntityProperty, ReferenceType } from '../BaseEntity';
+import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
 import { PropertyOptions } from './Property';
+import { IEntity } from './Entity';
 
 export function ManyToMany(options: ManyToManyOptions): Function {
-  return function (target: BaseEntity, propertyName: string) {
+  return function (target: IEntity, propertyName: string) {
     const entity = target.constructor.name;
     const storage = getMetadataStorage(entity);
     const meta = storage[entity];

--- a/lib/decorators/ManyToOne.ts
+++ b/lib/decorators/ManyToOne.ts
@@ -1,9 +1,10 @@
-import { BaseEntity, EntityProperty, ReferenceType } from '../BaseEntity';
+import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
 import { PropertyOptions } from './Property';
+import { IEntity } from './Entity';
 
 export function ManyToOne(options: ManyToOneOptions): Function {
-  return function (target: BaseEntity, propertyName: string) {
+  return function (target: IEntity, propertyName: string) {
     const entity = target.constructor.name;
     const storage = getMetadataStorage(entity);
 

--- a/lib/decorators/ManyToOne.ts
+++ b/lib/decorators/ManyToOne.ts
@@ -1,7 +1,6 @@
-import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
 import { PropertyOptions } from './Property';
-import { IEntity } from './Entity';
+import { EntityProperty, IEntity, ReferenceType } from './Entity';
 
 export function ManyToOne(options: ManyToOneOptions): Function {
   return function (target: IEntity, propertyName: string) {

--- a/lib/decorators/OneToMany.ts
+++ b/lib/decorators/OneToMany.ts
@@ -1,9 +1,10 @@
-import { BaseEntity, EntityProperty, ReferenceType } from '../BaseEntity';
+import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
 import { PropertyOptions } from './Property';
+import { IEntity } from './Entity';
 
 export function OneToMany(options: OneToManyOptions): Function {
-  return function (target: BaseEntity, propertyName: string) {
+  return function (target: IEntity, propertyName: string) {
     const entity = target.constructor.name;
     const storage = getMetadataStorage(entity);
 

--- a/lib/decorators/OneToMany.ts
+++ b/lib/decorators/OneToMany.ts
@@ -1,7 +1,6 @@
-import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
 import { PropertyOptions } from './Property';
-import { IEntity } from './Entity';
+import { EntityProperty, IEntity, ReferenceType } from './Entity';
 
 export function OneToMany(options: OneToManyOptions): Function {
   return function (target: IEntity, propertyName: string) {

--- a/lib/decorators/PrimaryKey.ts
+++ b/lib/decorators/PrimaryKey.ts
@@ -1,9 +1,9 @@
-import { BaseEntity, EntityProperty, ReferenceType } from '../BaseEntity';
+import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
-import { ObjectID } from '..';
+import { IEntity, ObjectID } from '..';
 
 export function PrimaryKey(options: PrimaryKeyOptions = {}): Function {
-  return function (target: BaseEntity, propertyName: string) {
+  return function (target: IEntity, propertyName: string) {
     const entity = target.constructor.name;
     const storage = getMetadataStorage(entity);
 

--- a/lib/decorators/PrimaryKey.ts
+++ b/lib/decorators/PrimaryKey.ts
@@ -1,6 +1,5 @@
-import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
-import { IEntity, ObjectID } from '..';
+import { EntityProperty, IEntity, ObjectID, ReferenceType } from '..';
 
 export function PrimaryKey(options: PrimaryKeyOptions = {}): Function {
   return function (target: IEntity, propertyName: string) {

--- a/lib/decorators/Property.ts
+++ b/lib/decorators/Property.ts
@@ -1,6 +1,5 @@
-import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
-import { IEntity } from './Entity';
+import { EntityProperty, IEntity, ReferenceType } from './Entity';
 
 export function Property(options: PropertyOptions = {}): Function {
   return function (target: IEntity, propertyName: string) {

--- a/lib/decorators/Property.ts
+++ b/lib/decorators/Property.ts
@@ -1,8 +1,9 @@
-import { BaseEntity, EntityProperty, ReferenceType } from '../BaseEntity';
+import { EntityProperty, ReferenceType } from '../BaseEntity';
 import { getMetadataStorage } from '../MikroORM';
+import { IEntity } from './Entity';
 
 export function Property(options: PropertyOptions = {}): Function {
-  return function (target: BaseEntity, propertyName: string) {
+  return function (target: IEntity, propertyName: string) {
     const entity = target.constructor.name;
     const storage = getMetadataStorage(entity);
 

--- a/lib/drivers/DatabaseDriver.ts
+++ b/lib/drivers/DatabaseDriver.ts
@@ -57,17 +57,23 @@ export abstract class DatabaseDriver implements IDatabaseDriver {
   /**
    * Begins a transaction (if supported)
    */
-  async begin(savepoint: string): Promise<void> { }
+  async begin(savepoint: string): Promise<void> {
+    throw new Error(`Transactions are not supported by ${this.constructor.name} driver`);
+  }
 
   /**
    * Commits statements in a transaction
    */
-  async commit(savepoint: string): Promise<void> { }
+  async commit(savepoint: string): Promise<void> {
+    throw new Error(`Transactions are not supported by ${this.constructor.name} driver`);
+  }
 
   /**
    * Rollback changes in a transaction
    */
-  async rollback(savepoint: string): Promise<void> { }
+  async rollback(savepoint: string): Promise<void> {
+    throw new Error(`Transactions are not supported by ${this.constructor.name} driver`);
+  }
 
   /**
    * Normalizes primary key wrapper to string value (e.g. mongodb's ObjectID)

--- a/lib/drivers/DatabaseDriver.ts
+++ b/lib/drivers/DatabaseDriver.ts
@@ -13,29 +13,14 @@ export abstract class DatabaseDriver implements IDatabaseDriver {
     this.metadata = getMetadataStorage();
   }
 
-  /**
-   * Establishes connection to database
-   */
   abstract async connect(): Promise<void>;
 
-  /**
-   * Are we connected to the database
-   */
   abstract async isConnected(): Promise<boolean>;
 
-  /**
-   * Closes the database connection (aka disconnect)
-   */
   abstract async close(force: boolean): Promise<void>;
 
-  /**
-   * Finds selection of entities
-   */
   abstract async find<T extends IEntity>(entityName: string, where: FilterQuery<T>, populate: string[], orderBy: { [p: string]: 1 | -1 }, limit: number, offset: number): Promise<T[]>;
 
-  /**
-   * Finds single entity (table row, document)
-   */
   abstract async findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | string, populate: string[]): Promise<T>;
 
   abstract async nativeInsert(entityName: string, data: any): Promise<IPrimaryKey>;
@@ -48,37 +33,26 @@ export abstract class DatabaseDriver implements IDatabaseDriver {
 
   abstract async count(entityName: string, where: any): Promise<number>;
 
-  /**
-   * Returns default client url for given driver (e.g. mongodb://localhost:27017 for mongodb)
-   */
   abstract getDefaultClientUrl(): string;
 
-  /**
-   * Begins a transaction (if supported)
-   */
   async begin(savepoint: string): Promise<void> {
     throw new Error(`Transactions are not supported by ${this.constructor.name} driver`);
   }
 
-  /**
-   * Commits statements in a transaction
-   */
   async commit(savepoint: string): Promise<void> {
     throw new Error(`Transactions are not supported by ${this.constructor.name} driver`);
   }
 
-  /**
-   * Rollback changes in a transaction
-   */
   async rollback(savepoint: string): Promise<void> {
     throw new Error(`Transactions are not supported by ${this.constructor.name} driver`);
   }
 
-  /**
-   * Normalizes primary key wrapper to string value (e.g. mongodb's ObjectID)
-   */
-  normalizePrimaryKey(where: any): string {
-    return where;
+  normalizePrimaryKey(data: IPrimaryKey): number | string {
+    return data as number | string;
+  }
+
+  denormalizePrimaryKey(data: number | string): IPrimaryKey {
+    return data;
   }
 
   getTableName(entityName: string): string {

--- a/lib/drivers/DatabaseDriver.ts
+++ b/lib/drivers/DatabaseDriver.ts
@@ -1,7 +1,7 @@
 import { getMetadataStorage, MikroORMOptions } from '../MikroORM';
-import { BaseEntity, EntityMetadata } from '../BaseEntity';
+import { EntityMetadata } from '../BaseEntity';
 import { IDatabaseDriver } from './IDatabaseDriver';
-import { IPrimaryKey } from '..';
+import { IEntity, IPrimaryKey } from '..';
 import { NamingStrategy } from '../naming-strategy/NamingStrategy';
 import { UnderscoreNamingStrategy } from '../naming-strategy/UnderscoreNamingStrategy';
 import { Utils } from '../Utils';
@@ -32,18 +32,18 @@ export abstract class DatabaseDriver implements IDatabaseDriver {
   /**
    * Finds selection of entities
    */
-  abstract async find<T extends BaseEntity>(entityName: string, where: FilterQuery<T>, populate: string[], orderBy: { [p: string]: 1 | -1 }, limit: number, offset: number): Promise<T[]>;
+  abstract async find<T extends IEntity>(entityName: string, where: FilterQuery<T>, populate: string[], orderBy: { [p: string]: 1 | -1 }, limit: number, offset: number): Promise<T[]>;
 
   /**
    * Finds single entity (table row, document)
    */
-  abstract async findOne<T extends BaseEntity>(entityName: string, where: FilterQuery<T> | string, populate: string[]): Promise<T>;
+  abstract async findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | string, populate: string[]): Promise<T>;
 
   abstract async nativeInsert(entityName: string, data: any): Promise<IPrimaryKey>;
 
-  abstract async nativeUpdate(entityName: string, where: FilterQuery<BaseEntity> | IPrimaryKey, data: any): Promise<number>;
+  abstract async nativeUpdate(entityName: string, where: FilterQuery<IEntity> | IPrimaryKey, data: any): Promise<number>;
 
-  abstract async nativeDelete(entityName: string, where: FilterQuery<BaseEntity> | IPrimaryKey): Promise<number>;
+  abstract async nativeDelete(entityName: string, where: FilterQuery<IEntity> | IPrimaryKey): Promise<number>;
 
   abstract async aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 

--- a/lib/drivers/DatabaseDriver.ts
+++ b/lib/drivers/DatabaseDriver.ts
@@ -1,7 +1,6 @@
 import { getMetadataStorage, MikroORMOptions } from '../MikroORM';
-import { EntityMetadata } from '../BaseEntity';
 import { IDatabaseDriver } from './IDatabaseDriver';
-import { IEntity, IPrimaryKey } from '..';
+import { IEntity, IPrimaryKey, EntityMetadata } from '..';
 import { NamingStrategy } from '../naming-strategy/NamingStrategy';
 import { UnderscoreNamingStrategy } from '../naming-strategy/UnderscoreNamingStrategy';
 import { Utils } from '../Utils';

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -1,6 +1,5 @@
-import { BaseEntity } from '../BaseEntity';
 import { FilterQuery } from './DatabaseDriver';
-import { IPrimaryKey } from '..';
+import { IEntity, IPrimaryKey } from '..';
 import { NamingStrategy } from '../naming-strategy/NamingStrategy';
 
 export interface IDatabaseDriver {
@@ -23,18 +22,18 @@ export interface IDatabaseDriver {
   /**
    * Finds selection of entities
    */
-  find<T extends BaseEntity>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: { [p: string]: 1 | -1 }, limit?: number, offset?: number): Promise<T[]>;
+  find<T extends IEntity>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: { [p: string]: 1 | -1 }, limit?: number, offset?: number): Promise<T[]>;
 
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends BaseEntity>(entityName: string, where: FilterQuery<T> | string, populate?: string[]): Promise<T>;
+  findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | string, populate?: string[]): Promise<T>;
 
   nativeInsert(entityName: string, data: any): Promise<IPrimaryKey>;
 
-  nativeUpdate(entityName: string, where: FilterQuery<BaseEntity> | IPrimaryKey, data: any): Promise<number>;
+  nativeUpdate(entityName: string, where: FilterQuery<IEntity> | IPrimaryKey, data: any): Promise<number>;
 
-  nativeDelete(entityName: string, where: FilterQuery<BaseEntity> | IPrimaryKey): Promise<number>;
+  nativeDelete(entityName: string, where: FilterQuery<IEntity> | IPrimaryKey): Promise<number>;
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -27,7 +27,7 @@ export interface IDatabaseDriver {
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | string, populate?: string[]): Promise<T>;
+  findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, populate?: string[]): Promise<T>;
 
   nativeInsert(entityName: string, data: any): Promise<IPrimaryKey>;
 
@@ -64,9 +64,14 @@ export interface IDatabaseDriver {
   rollback(savepoint?: string): Promise<void>;
 
   /**
-   * Normalizes primary key wrapper to string value (e.g. mongodb's ObjectID)
+   * Normalizes primary key wrapper to scalar value (e.g. mongodb's ObjectID to string)
    */
-  normalizePrimaryKey(where: any): string;
+  normalizePrimaryKey(data: IPrimaryKey): number | string;
+
+  /**
+   * De-normalizes primary key wrapper to value required by driver (e.g. string to mongodb's ObjectID)
+   */
+  denormalizePrimaryKey(data: any): IPrimaryKey;
 
   /**
    * NoSQL databases do require pivot table for M:N

--- a/lib/drivers/MongoDriver.ts
+++ b/lib/drivers/MongoDriver.ts
@@ -106,12 +106,16 @@ export class MongoDriver extends DatabaseDriver {
     return this.getCollection(this.metadata[entityName].collection).aggregate(pipeline).toArray();
   }
 
-  normalizePrimaryKey(data: any): string {
+  normalizePrimaryKey(data: IPrimaryKey): string {
     if (data instanceof ObjectID) {
       return data.toHexString();
     }
 
-    return data;
+    return data as string;
+  }
+
+  denormalizePrimaryKey(data: number | string): ObjectID {
+    return new ObjectID(data);
   }
 
   getDefaultClientUrl(): string {

--- a/lib/drivers/MySqlDriver.ts
+++ b/lib/drivers/MySqlDriver.ts
@@ -2,9 +2,8 @@ import { Connection, ConnectionOptions, createConnection } from 'mysql2/promise'
 import { readFileSync } from 'fs';
 import { URL } from 'url';
 import { DatabaseDriver, FilterQuery } from './DatabaseDriver';
-import { ReferenceType } from '../BaseEntity';
 import { QueryBuilder } from '../QueryBuilder';
-import { IEntity, IPrimaryKey } from '..';
+import { IEntity, IPrimaryKey, ReferenceType } from '..';
 import { Utils } from '../Utils';
 
 export class MySqlDriver extends DatabaseDriver {

--- a/lib/drivers/MySqlDriver.ts
+++ b/lib/drivers/MySqlDriver.ts
@@ -2,9 +2,9 @@ import { Connection, ConnectionOptions, createConnection } from 'mysql2/promise'
 import { readFileSync } from 'fs';
 import { URL } from 'url';
 import { DatabaseDriver, FilterQuery } from './DatabaseDriver';
-import { BaseEntity, ReferenceType } from '../BaseEntity';
+import { ReferenceType } from '../BaseEntity';
 import { QueryBuilder } from '../QueryBuilder';
-import { IPrimaryKey } from '..';
+import { IEntity, IPrimaryKey } from '..';
 import { Utils } from '../Utils';
 
 export class MySqlDriver extends DatabaseDriver {
@@ -52,7 +52,7 @@ export class MySqlDriver extends DatabaseDriver {
     return res[0][0].count;
   }
 
-  async find<T extends BaseEntity>(entityName: string, where: FilterQuery<T>, populate: string[] = [], orderBy: { [p: string]: 1 | -1 } = {}, limit?: number, offset?: number): Promise<T[]> {
+  async find<T extends IEntity>(entityName: string, where: FilterQuery<T>, populate: string[] = [], orderBy: { [p: string]: 1 | -1 } = {}, limit?: number, offset?: number): Promise<T[]> {
     const qb = new QueryBuilder(entityName, this.metadata);
     qb.select('*').populate(populate).where(where).orderBy(orderBy).limit(limit, offset);
     const res = await this.execute(qb);
@@ -60,7 +60,7 @@ export class MySqlDriver extends DatabaseDriver {
     return res[0].map(r => this.mapResult(r, this.metadata[entityName]));
   }
 
-  async findOne<T extends BaseEntity>(entityName: string, where: FilterQuery<T> | string, populate: string[] = []): Promise<T> {
+  async findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | string, populate: string[] = []): Promise<T> {
     if (Utils.isPrimaryKey(where)) {
       where = { id: where };
     }
@@ -86,7 +86,7 @@ export class MySqlDriver extends DatabaseDriver {
     return res[0].insertId;
   }
 
-  async nativeUpdate(entityName: string, where: FilterQuery<BaseEntity>, data: any): Promise<number> {
+  async nativeUpdate(entityName: string, where: FilterQuery<IEntity>, data: any): Promise<number> {
     if (Utils.isPrimaryKey(where)) {
       where = { id: where };
     }
@@ -105,7 +105,7 @@ export class MySqlDriver extends DatabaseDriver {
     return res ? res[0].affectedRows : 0;
   }
 
-  async nativeDelete(entityName: string, where: FilterQuery<BaseEntity> | string | any): Promise<number> {
+  async nativeDelete(entityName: string, where: FilterQuery<IEntity> | string | any): Promise<number> {
     if (Utils.isPrimaryKey(where)) {
       where = { id: where };
     }

--- a/tests/BaseEntity.test.ts
+++ b/tests/BaseEntity.test.ts
@@ -2,7 +2,6 @@ import { ObjectID } from 'bson';
 import { Author, Book, BookTag } from './entities';
 import { MikroORM } from '../lib';
 import { initORM, wipeDatabase } from './bootstrap';
-import { MongoDriver } from '../lib/drivers/MongoDriver';
 
 /**
  * @class BaseEntityTest

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -54,6 +54,7 @@ describe('EntityFactory', () => {
     expect(ref).toBeInstanceOf(Book);
     expect(ref.id).toBe('5b0d19b28b21c648c2c8a600');
     expect(ref.name).toBeUndefined();
+    expect(ref.toJSON()).toEqual({ id: '5b0d19b28b21c648c2c8a600' });
   });
 
   test('should return entity', async () => {

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -4,20 +4,14 @@ import { MikroORM } from '../lib';
 import { initORM, wipeDatabase } from './bootstrap';
 
 /**
- * @class BaseEntityTest
+ * @class EntityHelperMongoTest
  */
-describe('BaseEntity', () => {
+describe('EntityHelperMongo', () => {
 
   let orm: MikroORM;
 
   beforeAll(async () => orm = await initORM());
   beforeEach(async () => wipeDatabase(orm.em));
-
-  beforeEach(async () => {
-    await orm.em.getRepository<Author>(Author.name).remove({});
-    await orm.em.getRepository<Book>(Book.name).remove({});
-    await orm.em.getRepository<BookTag>(BookTag.name).remove({});
-  });
 
   test('#toObject() should return DTO', async () => {
     const author = new Author('Jon Snow', 'snow@wall.st');
@@ -67,11 +61,13 @@ describe('BaseEntity', () => {
     book.assign({ tags: [other._id] });
     expect(book.tags.getIdentifiers('_id')).toMatchObject([other._id]);
     book.assign({ tags: [] });
-    expect(book.tags.getIdentifiers('_id')).toMatchObject([]);
+    expect(book.tags.getIdentifiers()).toMatchObject([]);
     book.assign({ tags: [tag1.id, tag3.id] });
     expect(book.tags.getIdentifiers()).toMatchObject([tag1.id, tag3.id]);
     book.assign({ tags: [tag2] });
     expect(book.tags.getIdentifiers('_id')).toMatchObject([tag2._id]);
+    expect(() => book.assign({ tags: [{ foo: 'bar' }] })).toThrowError(`Invalid collection values provided for 'Book.tags' in Book.assign(): [{"foo":"bar"}]`);
+    expect(() => book.assign({ publisher: [{ foo: 'bar' }] })).toThrowError(`Invalid reference value provided for 'Book.publisher' in Book.assign(): [{"foo":"bar"}]`);
   });
 
   test('should have string id getter and setter', async () => {

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -1,0 +1,58 @@
+import { MikroORM } from '../lib';
+import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
+import { Author2, Book2, BookTag2 } from './entities-mysql';
+
+/**
+ * @class EntityHelperMySqlTest
+ */
+describe('EntityHelperMySql', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => orm = await initORMMySql());
+  beforeEach(async () => wipeDatabaseMySql(orm.em));
+
+  test('#assign() should update entity values [mysql]', async () => {
+    const god = new Author2('God', 'hello@heaven.god');
+    const jon = new Author2('Jon Snow', 'snow@wall.st');
+    const book = new Book2('Book2', jon);
+    await orm.em.persist(book);
+    expect(book.title).toBe('Book2');
+    expect(book.author).toBe(jon);
+    book.assign({ title: 'Better Book2 1', author: god, notExisting: true });
+    expect(book.author).toBe(god);
+    expect(book.notExisting).toBe(true);
+    await orm.em.persist(god);
+    book.assign({ title: 'Better Book2 2', author: god.id });
+    expect(book.author).toBe(god);
+    book.assign({ title: 'Better Book2 3', author: jon.id });
+    expect(book.title).toBe('Better Book2 3');
+    expect(book.author).toBe(jon);
+  });
+
+  test('#assign() should update entity collection [mysql]', async () => {
+    const other = new BookTag2('other');
+    other.id = null;
+    await orm.em.persist(other);
+    const jon = new Author2('Jon Snow', 'snow@wall.st');
+    const book = new Book2('Book2', jon);
+    const tag1 = new BookTag2('tag 1');
+    const tag2 = new BookTag2('tag 2');
+    const tag3 = new BookTag2('tag 3');
+    book.tags.add(tag1);
+    book.tags.add(tag2);
+    book.tags.add(tag3);
+    await orm.em.persist(book);
+    book.assign({ tags: [other.id] });
+    expect(book.tags.getIdentifiers()).toMatchObject([other.id]);
+    book.assign({ tags: [] });
+    expect(book.tags.getIdentifiers()).toMatchObject([]);
+    book.assign({ tags: [tag1.id, tag3.id] });
+    expect(book.tags.getIdentifiers()).toMatchObject([tag1.id, tag3.id]);
+    book.assign({ tags: [tag2] });
+    expect(book.tags.getIdentifiers()).toMatchObject([tag2.id]);
+  });
+
+  afterAll(async () => orm.close(true));
+
+});

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -540,6 +540,12 @@ describe('EntityManagerMongo', () => {
     expect(res6).toBe(1);
   });
 
+  test('EM do not support transactions', async () => {
+    await expect(orm.em.begin()).rejects.toThrowError('Transactions are not supported by MongoDriver driver');
+    await expect(orm.em.rollback()).rejects.toThrowError('Transactions are not supported by MongoDriver driver');
+    await expect(orm.em.commit()).rejects.toThrowError('Transactions are not supported by MongoDriver driver');
+  });
+
   afterAll(async () => orm.close(true));
 
 });

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1,6 +1,7 @@
 import { Collection, EntityManager, MikroORM, MySqlDriver } from '../lib';
 import { Author2, Publisher2, PublisherType, Book2, BookTag2, Test2 } from './entities-mysql';
 import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
+import { Utils } from '../lib/Utils';
 
 /**
  * @class EntityManagerMySqlTest
@@ -537,6 +538,18 @@ describe('EntityManagerMySql', () => {
 
     const res6 = await orm.em.nativeUpdate(Author2.name, { name: 'native name 2' }, { name: 'new native name', updatedAt: new Date('2018-10-28') });
     expect(res6).toBe(1);
+  });
+
+  test('Utils.prepareEntity changes entity to number id', async () => {
+    const author1 = new Author2('Name 1', 'e-mail');
+    const book = new Book2('test', author1);
+    const author2 = new Author2('Name 2', 'e-mail');
+    author2.favouriteBook = book;
+    author2.version = 123;
+    await orm.em.persist([author1, author2, book]);
+    const diff = Utils.diffEntities(author1, author2, orm.em.getDriver());
+    expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.id });
+    expect(typeof diff.favouriteBook).toBe('number');
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -2,8 +2,7 @@ import { ObjectID } from 'bson';
 import { Utils } from '../lib/Utils';
 import { Collection, MikroORM } from '../lib';
 import { Author, Book } from './entities';
-import { initORM, initORMMySql, wipeDatabase, wipeDatabaseMySql } from './bootstrap';
-import { Author2, Book2 } from './entities-mysql';
+import { initORM, wipeDatabase } from './bootstrap';
 
 class Test {}
 
@@ -13,16 +12,9 @@ class Test {}
 describe('Utils', () => {
 
   let orm: MikroORM;
-  let ormMySql: MikroORM;
 
-  beforeAll(async () => {
-    orm = await initORM();
-    ormMySql = await initORMMySql();
-  });
-  beforeEach(async () => {
-    await wipeDatabase(orm.em);
-    await wipeDatabaseMySql(ormMySql.em);
-  });
+  beforeAll(async () => orm = await initORM());
+  beforeEach(async () => wipeDatabase(orm.em));
 
   test('isObject', () => {
     expect(Utils.isObject(undefined)).toBe(false);
@@ -98,18 +90,6 @@ describe('Utils', () => {
     expect(diff.favouriteBook instanceof ObjectID).toBe(true);
   });
 
-  test('prepareEntity changes entity to number id [mysql]', async () => {
-    const author1 = new Author2('Name 1', 'e-mail');
-    const book = new Book2('test', author1);
-    const author2 = new Author2('Name 2', 'e-mail');
-    author2.favouriteBook = book;
-    author2.version = 123;
-    await ormMySql.em.persist([author1, author2, book]);
-    const diff = Utils.diffEntities(author1, author2, ormMySql.em.getDriver());
-    expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.id });
-    expect(typeof diff.favouriteBook).toBe('number');
-  });
-
   test('copy', () => {
     const a = {a: 'a', b: 'c'};
     const b = Utils.copy(a);
@@ -146,9 +126,6 @@ describe('Utils', () => {
     expect(Utils.extractPK(true)).toBeNull();
   });
 
-  afterAll(async () => {
-    await orm.close(true);
-    await ormMySql.close(true);
-  });
+  afterAll(async () => orm.close(true));
 
 });

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -1,6 +1,6 @@
 import { ObjectID } from 'bson';
 import { Utils } from '../lib/Utils';
-import { Collection, EntityProperty, MikroORM } from '../lib';
+import { Collection, MikroORM } from '../lib';
 import { Author, Book } from './entities';
 import { initORM, wipeDatabase } from './bootstrap';
 
@@ -66,6 +66,7 @@ describe('Utils', () => {
     expect(Utils.diff({a: 'a'}, {a: 'b', b: ['c']})).toEqual({a: 'b', b: ['c']});
     expect(Utils.diff({a: 'a', b: ['c']}, {b: []})).toEqual({b: []});
     expect(Utils.diff({a: 'a', b: ['c']}, {a: 'b'})).toEqual({a: 'b'});
+    expect(Utils.diff({a: 'a', b: ['c']}, {a: undefined})).toEqual({a: undefined});
     expect(Utils.diff({a: new Date()}, {a: new Date('2018-01-01')})).toEqual({a: new Date('2018-01-01')});
   });
 

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -71,9 +71,9 @@ describe('Utils', () => {
 
   test('diffEntities ignores collections', () => {
     const author1 = new Author('Name 1', 'e-mail');
-    author1.books = new Collection<Book>(author1, {} as EntityProperty);
+    author1.books = new Collection<Book>(author1);
     const author2 = new Author('Name 2', 'e-mail');
-    author2.books = new Collection<Book>(author2, {} as EntityProperty);
+    author2.books = new Collection<Book>(author2);
     expect(Utils.diffEntities(author1, author2).books).toBeUndefined();
   });
 

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -40,7 +40,7 @@ export class Author {
   born: Date;
 
   @OneToMany({ entity: () => Book, fk: 'author' })
-  books = new Collection<Book>(this, 'books', []);
+  books = new Collection<Book>(this);
 
   @ManyToOne({ entity: () => Book })
   favouriteBook: Book;

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate,
-  BaseEntity, Collection, Entity, OneToMany, Property, ManyToOne, PrimaryKey, ObjectID,
+  BaseEntity, Collection, Entity, OneToMany, Property, ManyToOne, PrimaryKey, ObjectID, IEntity,
 } from '../../lib';
 
 import { Book } from './Book';

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,13 +1,13 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate,
-  BaseEntity, Collection, Entity, OneToMany, Property, ManyToOne, PrimaryKey, ObjectID,
+  Collection, Entity, OneToMany, Property, ManyToOne, PrimaryKey, ObjectID, IEntity,
 } from '../../lib';
 
 import { Book } from './Book';
 import { AuthorRepository } from '../repositories/AuthorRepository';
 
 @Entity({ customRepository: () => AuthorRepository })
-export class Author extends BaseEntity {
+export class Author {
 
   static beforeDestroyCalled = 0;
   static afterDestroyCalled = 0;
@@ -40,7 +40,7 @@ export class Author extends BaseEntity {
   born: Date;
 
   @OneToMany({ entity: () => Book, fk: 'author' })
-  books: Collection<Book>;
+  books = new Collection<Book>(this, 'books', []);
 
   @ManyToOne({ entity: () => Book })
   favouriteBook: Book;
@@ -49,7 +49,6 @@ export class Author extends BaseEntity {
   versionAsString: string;
 
   constructor(name: string, email: string) {
-    super();
     this.name = name;
     this.email = email;
   }
@@ -85,3 +84,5 @@ export class Author extends BaseEntity {
   }
 
 }
+
+export interface Author extends IEntity { }

--- a/tests/entities/Author.ts
+++ b/tests/entities/Author.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate,
-  BaseEntity, Collection, Entity, OneToMany, Property, ManyToOne, PrimaryKey, ObjectID, IEntity,
+  BaseEntity, Collection, Entity, OneToMany, Property, ManyToOne, PrimaryKey, ObjectID,
 } from '../../lib';
 
 import { Book } from './Book';

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,20 +1,10 @@
-import {
-  BaseEntity,
-  Collection,
-  Entity,
-  ManyToMany,
-  ManyToOne,
-  PrimaryKey,
-  Property,
-  ObjectID,
-  IEntity,
-} from '../../lib';
+import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property, ObjectID, IEntity } from '../../lib';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './BookTag';
 
 @Entity({ collection: 'books-table' })
-export class Book extends BaseEntity {
+export class Book {
 
   @PrimaryKey()
   _id: ObjectID;
@@ -29,7 +19,7 @@ export class Book extends BaseEntity {
   publisher: Publisher;
 
   @ManyToMany({ entity: () => BookTag.name, inversedBy: 'books' })
-  tags: Collection<BookTag>;
+  tags = new Collection<BookTag>(this, 'tags', []);
 
   @Property()
   metaObject: object;
@@ -41,9 +31,10 @@ export class Book extends BaseEntity {
   metaArrayOfStrings: string[];
 
   constructor(title: string, author: Author) {
-    super();
     this.title = title;
     this.author = author;
   }
 
 }
+
+export interface Book extends IEntity { }

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -1,4 +1,14 @@
-import { BaseEntity, Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property, ObjectID } from '../../lib';
+import {
+  BaseEntity,
+  Collection,
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ObjectID,
+  IEntity,
+} from '../../lib';
 import { Publisher } from './Publisher';
 import { Author } from './Author';
 import { BookTag } from './BookTag';

--- a/tests/entities/Book.ts
+++ b/tests/entities/Book.ts
@@ -19,7 +19,7 @@ export class Book {
   publisher: Publisher;
 
   @ManyToMany({ entity: () => BookTag.name, inversedBy: 'books' })
-  tags = new Collection<BookTag>(this, 'tags', []);
+  tags = new Collection<BookTag>(this);
 
   @Property()
   metaObject: object;

--- a/tests/entities/BookTag.ts
+++ b/tests/entities/BookTag.ts
@@ -1,8 +1,8 @@
-import { BaseEntity, Collection, Entity, ManyToMany, PrimaryKey, Property, ObjectID } from '../../lib';
+import { Collection, Entity, ManyToMany, PrimaryKey, Property, ObjectID, IEntity } from '../../lib';
 import { Book } from './Book';
 
 @Entity()
-export class BookTag extends BaseEntity {
+export class BookTag {
 
   @PrimaryKey()
   _id: ObjectID;
@@ -11,11 +11,12 @@ export class BookTag extends BaseEntity {
   name: string;
 
   @ManyToMany({ entity: () => Book.name, mappedBy: 'tags' })
-  books: Collection<Book>;
+  books = new Collection<Book>(this, 'books', []);
 
   constructor(name: string) {
-    super();
     this.name = name;
   }
 
 }
+
+export interface BookTag extends IEntity { }

--- a/tests/entities/BookTag.ts
+++ b/tests/entities/BookTag.ts
@@ -11,7 +11,7 @@ export class BookTag {
   name: string;
 
   @ManyToMany({ entity: () => Book.name, mappedBy: 'tags' })
-  books = new Collection<Book>(this, 'books', []);
+  books = new Collection<Book>(this);
 
   constructor(name: string) {
     this.name = name;

--- a/tests/entities/Publisher.ts
+++ b/tests/entities/Publisher.ts
@@ -1,9 +1,9 @@
-import { BaseEntity, Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property, ObjectID } from '../../lib';
+import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property, ObjectID, IEntity } from '../../lib';
 import { Book } from './Book';
 import { Test } from './Test';
 
 @Entity()
-export class Publisher extends BaseEntity {
+export class Publisher {
 
   @PrimaryKey()
   _id: ObjectID;
@@ -12,21 +12,22 @@ export class Publisher extends BaseEntity {
   name: string;
 
   @OneToMany({ entity: () => Book.name, fk: 'publisher' })
-  books: Collection<Book>;
+  books = new Collection<Book>(this, 'books', []);
 
   @ManyToMany({ entity: () => Test.name, owner: true })
-  tests: Collection<Test>;
+  tests = new Collection<Test>(this, 'tests', []);
 
   @Property()
   type: PublisherType = PublisherType.LOCAL;
 
   constructor(name: string = 'asd', type: PublisherType = PublisherType.LOCAL) {
-    super();
     this.name = name;
     this.type = type;
   }
 
 }
+
+export interface Publisher extends IEntity { }
 
 export enum PublisherType {
   LOCAL = 'local',

--- a/tests/entities/Publisher.ts
+++ b/tests/entities/Publisher.ts
@@ -12,10 +12,10 @@ export class Publisher {
   name: string;
 
   @OneToMany({ entity: () => Book.name, fk: 'publisher' })
-  books = new Collection<Book>(this, 'books', []);
+  books = new Collection<Book>(this);
 
   @ManyToMany({ entity: () => Test.name, owner: true })
-  tests = new Collection<Test>(this, 'tests', []);
+  tests = new Collection<Test>(this);
 
   @Property()
   type: PublisherType = PublisherType.LOCAL;

--- a/tests/entities/Test.ts
+++ b/tests/entities/Test.ts
@@ -1,7 +1,7 @@
-import { BaseEntity, Entity, PrimaryKey, Property, ObjectID } from '../../lib';
+import { Entity, PrimaryKey, Property, ObjectID, IEntity } from '../../lib';
 
 @Entity()
-export class Test extends BaseEntity {
+export class Test {
 
   @PrimaryKey()
   _id: ObjectID;
@@ -17,3 +17,5 @@ export class Test extends BaseEntity {
   }
 
 }
+
+export interface Test extends IEntity { }


### PR DESCRIPTION
Progress:
- [x] Move internal helpers to `@Entity` decorator (monkey patch the entity)
- [x] Move serialisation and assign methods to `EntityHelper` and add shortcuts in `@Entity` decorator
- [x] Allow usage without `BaseEntity`
- [x] Reorganize entity interfaces defined in `BaseEntity` and `@Entity` decorator
- [x] Update README
