### PR TITLE
Refactor unit of work to never run queries before committing

### DIFF
--- a/lib/EntityFactory.ts
+++ b/lib/EntityFactory.ts
@@ -1,9 +1,10 @@
 import { Collection } from './Collection';
-import { EntityManager } from './EntityManager';
 import { IPrimaryKey } from './decorators/PrimaryKey';
 import { EntityClass, EntityData, EntityMetadata, IEntity, IEntityType, ReferenceType } from './decorators/Entity';
 import { Utils } from './utils/Utils';
 import { MetadataStorage } from './metadata/MetadataStorage';
+import { UnitOfWork } from './UnitOfWork';
+import { IDatabaseDriver } from './drivers/IDatabaseDriver';
 
 export const SCALAR_TYPES = ['string', 'number', 'boolean', 'Date'];
 
@@ -11,7 +12,8 @@ export class EntityFactory {
 
   private readonly metadata = MetadataStorage.getMetadata();
 
-  constructor(private em: EntityManager) { }
+  constructor(private readonly unitOfWork: UnitOfWork,
+              private readonly driver: IDatabaseDriver) { }
 
   create<T extends IEntityType<T>>(entityName: string | EntityClass<T>, data: EntityData<T>, initialized = true): T {
     entityName = Utils.className(entityName);
@@ -22,7 +24,7 @@ export class EntityFactory {
 
     // normalize PK to `id: string`
     if (data.id || data._id) {
-      data.id = this.em.getDriver().normalizePrimaryKey(data.id || data._id);
+      data.id = this.driver.normalizePrimaryKey(data.id || data._id);
       delete data._id;
     }
 
@@ -30,13 +32,13 @@ export class EntityFactory {
       const params = this.extractConstructorParams<T>(meta, data);
       entity = new Entity(...params);
       exclude.push(...meta.constructorParams);
-    } else if (this.em.getIdentity(entityName, data.id)) {
-      entity = this.em.getIdentity<T>(entityName, data.id);
+    } else if (this.unitOfWork.getById(entityName, data.id)) {
+      entity = this.unitOfWork.getById<T>(entityName, data.id);
     } else {
       // creates new entity instance, with possibility to bypass constructor call when instancing already persisted entity
       entity = Object.create(Entity.prototype);
       entity.id = data.id as number | string;
-      this.em.setIdentity(entity);
+      this.unitOfWork.addToIdentityMap(entity);
     }
 
     this.initEntity(entity, meta, data, exclude);
@@ -51,8 +53,10 @@ export class EntityFactory {
   }
 
   createReference<T extends IEntityType<T>>(entityName: string | EntityClass<T>, id: IPrimaryKey): T {
-    if (this.em.getIdentity<T>(entityName, id)) {
-      return this.em.getIdentity<T>(entityName, id);
+    entityName = Utils.className(entityName);
+
+    if (this.unitOfWork.getById(entityName, id)) {
+      return this.unitOfWork.getById<T>(entityName, id);
     }
 
     return this.create<T>(entityName, { id } as EntityData<T>, false);
@@ -75,18 +79,17 @@ export class EntityFactory {
 
       if (prop.reference === ReferenceType.MANY_TO_MANY) {
         if (prop.owner && Array.isArray(value)) {
-          const driver = this.em.getDriver();
-          const items = value.map((id: IPrimaryKey) => this.createReference(prop.type, driver.normalizePrimaryKey(id)));
+          const items = value.map((id: IPrimaryKey) => this.createReference(prop.type, this.driver.normalizePrimaryKey(id)));
           return entity[prop.name as keyof T] = new Collection<IEntity>(entity, items) as T[keyof T];
         } else if (!entity[prop.name as keyof T]) {
-          const items = prop.owner && !this.em.getDriver().getConfig().usesPivotTable ? [] : undefined;
+          const items = prop.owner && !this.driver.getConfig().usesPivotTable ? [] : undefined;
           return entity[prop.name as keyof T] = new Collection<IEntity>(entity, items, false) as T[keyof T];
         }
       }
 
       if (prop.reference === ReferenceType.MANY_TO_ONE) {
         if (value && !Utils.isEntity(value)) {
-          const id = this.em.getDriver().normalizePrimaryKey(value as IPrimaryKey);
+          const id = this.driver.normalizePrimaryKey(value as IPrimaryKey);
           entity[prop.name as keyof T] = this.createReference(prop.type, id as IPrimaryKey);
         }
 
@@ -104,13 +107,12 @@ export class EntityFactory {
    */
   private extractConstructorParams<T extends IEntityType<T>>(meta: EntityMetadata<T>, data: EntityData<T>): T[keyof T][] {
     return meta.constructorParams.map(k => {
-      const value = data[k];
-
-      if (meta.properties[k].reference === ReferenceType.MANY_TO_ONE && value) {
-        return this.em.getReference(meta.properties[k].type, value) as T[keyof T];
+      if (meta.properties[k].reference === ReferenceType.MANY_TO_ONE && data[k]) {
+        const entity = this.unitOfWork.getById(meta.properties[k].type, data[k]) as T[keyof T];
+        return entity || this.createReference(meta.properties[k].type, data[k]);
       }
 
-      return data[k] as T[keyof T];
+      return data[k];
     });
   }
 

--- a/lib/EntityFactory.ts
+++ b/lib/EntityFactory.ts
@@ -16,6 +16,7 @@ export class EntityFactory {
   create<T extends IEntityType<T>>(entityName: string | EntityClass<T>, data: EntityData<T>, initialized = true): T {
     entityName = Utils.className(entityName);
     const meta = this.metadata[entityName];
+    const Entity = require(meta.path)[meta.name];
     const exclude: string[] = [];
     let entity: T;
 
@@ -27,16 +28,15 @@ export class EntityFactory {
 
     if (!data.id) {
       const params = this.extractConstructorParams<T>(meta, data);
-      const Entity = require(meta.path)[entityName];
       entity = new Entity(...params);
       exclude.push(...meta.constructorParams);
     } else if (this.em.getIdentity(entityName, data.id)) {
       entity = this.em.getIdentity<T>(entityName, data.id);
     } else {
       // creates new entity instance, with possibility to bypass constructor call when instancing already persisted entity
-      const Entity = require(meta.path)[meta.name];
       entity = Object.create(Entity.prototype);
-      this.em.setIdentity(entity, data.id);
+      entity.id = data.id as number | string;
+      this.em.setIdentity(entity);
     }
 
     this.initEntity(entity, meta, data, exclude);

--- a/lib/EntityManager.ts
+++ b/lib/EntityManager.ts
@@ -21,35 +21,17 @@ export class EntityManager {
   readonly validator = new Validator(this.options.strict);
 
   private readonly repositoryMap: { [k: string]: EntityRepository<IEntity> } = {};
-  private readonly entityFactory = new EntityFactory(this);
   private readonly entityLoader = new EntityLoader(this);
   private readonly metadata = MetadataStorage.getMetadata();
-  private readonly _unitOfWork = new UnitOfWork(this);
+  private readonly unitOfWork = new UnitOfWork(this);
+  private readonly entityFactory = new EntityFactory(this.unitOfWork, this.driver);
 
   constructor(readonly options: MikroORMOptions,
               private readonly driver: IDatabaseDriver<Connection>) {
   }
 
-  getIdentity<T extends IEntityType<T>>(entityName: string | EntityClass<T>, id: IPrimaryKey): T {
-    entityName = Utils.className(entityName);
-    return this.unitOfWork.getById<T>(entityName, id);
-  }
-
-  setIdentity<T extends IEntityType<T>>(entity: T): void {
-    this.unitOfWork.addToIdentityMap(entity);
-  }
-
-  unsetIdentity(entity: IEntity): void {
-    this.unitOfWork.unsetIdentity(entity);
-  }
-
   getIdentityMap(): Record<string, IEntity> {
-    return this.unitOfWork.getIdentityMap();
-  }
-
-  addToIdentityMap(entity: IEntity) {
-    this.setIdentity(entity);
-    this.unitOfWork.addToIdentityMap(entity);
+    return this.getUnitOfWork().getIdentityMap();
   }
 
   getDriver<D extends IDatabaseDriver<Connection> = IDatabaseDriver<Connection>>(): D {
@@ -67,8 +49,8 @@ export class EntityManager {
       const meta = this.metadata[entityName];
 
       if (meta.customRepository) {
-        const customRepository = meta.customRepository();
-        this.repositoryMap[entityName] = new customRepository(this, entityName);
+        const CustomRepository = meta.customRepository();
+        this.repositoryMap[entityName] = new CustomRepository(this, entityName);
       } else {
         this.repositoryMap[entityName] = new EntityRepository<T>(this, entityName);
       }
@@ -110,13 +92,14 @@ export class EntityManager {
       throw new Error(`You cannot call 'EntityManager.findOne()' with empty 'where' parameter`);
     }
 
-    where = this.driver.normalizePrimaryKey(where as IPrimaryKey);
+    if (Utils.isPrimaryKey(where)) {
+      where = this.driver.normalizePrimaryKey<IPrimaryKey>(where);
+      const entity = this.getUnitOfWork().getById<T>(entityName, where);
 
-    if (Utils.isPrimaryKey(where) && this.getIdentity(entityName, where as IPrimaryKey) && this.getIdentity(entityName, where as IPrimaryKey).isInitialized()) {
-      const entity = this.getIdentity<T>(entityName, where as IPrimaryKey);
-      await this.entityLoader.populate(entityName, [entity], populate);
-
-      return entity;
+      if (entity && entity.isInitialized()) {
+        await this.entityLoader.populate(entityName, [entity], populate);
+        return entity;
+      }
     }
 
     this.validator.validateParams(where);
@@ -189,13 +172,8 @@ export class EntityManager {
     }
 
     const entity = Utils.isEntity<T>(data) ? data : this.entityFactory.create<T>(entityName, data, true);
-
-    if (this.getIdentity<T>(entityName, entity.id)) {
-      EntityHelper.assign(entity, data);
-      this.unitOfWork.addToIdentityMap(entity);
-    } else {
-      this.addToIdentityMap(entity);
-    }
+    EntityHelper.assign(entity, data);
+    this.getUnitOfWork().addToIdentityMap(entity);
 
     return entity as T;
   }
@@ -214,8 +192,8 @@ export class EntityManager {
   getReference<T extends IEntityType<T>>(entityName: string | EntityClass<T>, id: IPrimaryKey): T {
     entityName = Utils.className(entityName);
 
-    if (this.getIdentity(entityName, id)) {
-      return this.getIdentity<T>(entityName, id);
+    if (this.getUnitOfWork().getById(entityName, id)) {
+      return this.getUnitOfWork().getById<T>(entityName, id);
     }
 
     return this.entityFactory.createReference<T>(entityName, id);
@@ -232,7 +210,7 @@ export class EntityManager {
 
     for (const ent of entity) {
       await this.cascade(ent, Cascade.PERSIST, async (e: IEntity) => {
-        this.unitOfWork.persist(e);
+        this.getUnitOfWork().persist(e);
       });
     }
 
@@ -254,8 +232,7 @@ export class EntityManager {
 
   async removeEntity(entity: IEntity, flush = true): Promise<void> {
     await this.cascade(entity, Cascade.REMOVE, async (e: IEntity) => {
-      this.unitOfWork.remove(e);
-      this.unsetIdentity(e);
+      this.getUnitOfWork().remove(e);
     });
 
     if (flush) {
@@ -267,16 +244,14 @@ export class EntityManager {
    * flush changes to database
    */
   async flush(): Promise<void> {
-    await this.unitOfWork.commit();
+    await this.getUnitOfWork().commit();
   }
 
   /**
    * clear identity map, detaching all entities
    */
   clear(): void {
-    const map = this.getIdentityMap();
-    Object.keys(map).forEach(key => delete map[key]);
-    this.unitOfWork.clear();
+    this.getUnitOfWork().clear();
   }
 
   canPopulate(entityName: string | Function, property: string): boolean {
@@ -298,6 +273,11 @@ export class EntityManager {
 
   fork(): EntityManager {
     return new EntityManager(this.options, this.driver);
+  }
+
+  getUnitOfWork(): UnitOfWork {
+    const em = RequestContext.getEntityManager() || this;
+    return em.unitOfWork;
   }
 
   private async cascade<T extends IEntityType<T>>(entity: T, type: Cascade, cb: (e: IEntity) => Promise<void>, visited: IEntity[] = []): Promise<void> {
@@ -329,11 +309,6 @@ export class EntityManager {
         }
       }
     }
-  }
-
-  private get unitOfWork(): UnitOfWork {
-    const em = RequestContext.getEntityManager() || this;
-    return em._unitOfWork;
   }
 
 }

--- a/lib/UnitOfWork.ts
+++ b/lib/UnitOfWork.ts
@@ -162,13 +162,8 @@ export class UnitOfWork {
     }
   }
 
-  private findNewEntities<T extends IEntityType<T>>(entity: T, visited: IEntity[] = []): void {
-    if (visited.includes(entity)) {
-      return;
-    }
-
+  private findNewEntities<T extends IEntityType<T>>(entity: T): void {
     const meta = this.metadata[entity.constructor.name] as EntityMetadata<T>;
-    visited.push(entity);
 
     if (!entity.id && !this.identifierMap[entity.uuid]) {
       this.identifierMap[entity.uuid] = new EntityIdentifier();
@@ -180,12 +175,12 @@ export class UnitOfWork {
       if (prop.reference === ReferenceType.MANY_TO_MANY && (reference as Collection<IEntity>).isDirty()) {
         for (const item of (reference as Collection<IEntity>).getItems()) {
           if (!this.hasIdentifier(item)) {
-            this.findNewEntities(item, visited);
+            this.findNewEntities(item);
           }
         }
       } else if (prop.reference === ReferenceType.MANY_TO_ONE && reference) {
         if (!this.hasIdentifier(reference)) {
-          this.findNewEntities(reference, visited);
+          this.findNewEntities(reference);
         }
       }
     }

--- a/lib/UnitOfWork.ts
+++ b/lib/UnitOfWork.ts
@@ -1,6 +1,7 @@
 import { Utils } from './utils/Utils';
 import { EntityManager } from './EntityManager';
-import { EntityData, EntityMetadata, EntityProperty, IEntity, IEntityType, ReferenceType } from './decorators/Entity';
+import { EntityData, EntityMetadata, IEntity, IEntityType, ReferenceType } from './decorators/Entity';
+import { IPrimaryKey } from './decorators/PrimaryKey';
 import { MetadataStorage } from './metadata/MetadataStorage';
 import { Collection } from './Collection';
 
@@ -8,7 +9,10 @@ export class UnitOfWork {
 
   // holds copy of entity manager's identity map so we can compute changes when persisting
   private readonly identityMap = {} as Record<string, IEntity>;
-  private readonly persistStack: ChangeSet[] = [];
+  private readonly identifierMap = {} as Record<string, Identifier>;
+  private readonly persistStack: IEntity[] = [];
+  private readonly removeStack: IEntity[] = [];
+  private readonly changeSets: ChangeSet[] = [];
   private readonly metadata = MetadataStorage.getMetadata();
 
   constructor(private em: EntityManager) { }
@@ -17,44 +21,38 @@ export class UnitOfWork {
     this.identityMap[`${entity.constructor.name}-${entity.id}`] = Utils.copy(entity);
   }
 
-  async persist(entity: IEntity): Promise<ChangeSet | null> {
-    const changeSet = await this.computeChangeSet(entity);
-
-    if (!changeSet) {
-      return null;
+  persist<T extends IEntityType<T>>(entity: T): void {
+    if (this.persistStack.includes(entity)) {
+      return;
     }
-
-    changeSet.index = this.persistStack.length;
-    this.persistStack.push(changeSet);
-    this.addToIdentityMap(entity);
-
-    return changeSet;
-  }
-
-  async remove(entity: IEntity): Promise<ChangeSet | null> {
-    const meta = this.metadata[entity.constructor.name];
-
-    // clean up persist stack from previous change sets for this entity (in case there was persist call without flushing)
-    this.persistStack.forEach(changeSet => {
-      if (changeSet.entity === entity) {
-        this.persistStack.splice(changeSet.index, 1);
-      }
-    });
 
     if (!entity.id) {
-      return null;
+      this.identifierMap[entity.uuid] = new Identifier();
     }
 
-    const changeSet = { entity, delete: true, name: meta.name, collection: meta.collection, payload: {} } as ChangeSet;
-    changeSet.index = this.persistStack.length;
-    this.persistStack.push(changeSet);
+    this.persistStack.push(entity);
+    this.cleanUpStack(this.removeStack, entity);
+  }
 
-    return changeSet;
+  remove(entity: IEntity): void {
+    if (this.removeStack.includes(entity)) {
+      return;
+    }
+
+    if (entity.id) {
+      this.removeStack.push(entity);
+    } else {
+      delete this.identifierMap[entity.uuid];
+    }
+
+    this.cleanUpStack(this.persistStack, entity);
   }
 
   async commit(): Promise<void> {
-    if (this.persistStack.length === 0) {
-      return; // nothing to do, do not start transaction
+    this.computeChangeSets();
+
+    if (this.changeSets.length === 0) {
+      return this.clear(false); // nothing to do, do not start transaction
     }
 
     const driver = this.em.getDriver();
@@ -62,104 +60,147 @@ export class UnitOfWork {
 
     if (runInTransaction) {
       await driver.transactional(async () => {
-        for (const changeSet of this.persistStack) {
-          await this.immediateCommit(changeSet, false);
+        for (const changeSet of this.changeSets) {
+          await this.commitChangeSet(changeSet);
         }
       });
     } else {
-      for (const changeSet of this.persistStack) {
-        await this.immediateCommit(changeSet, false);
+      for (const changeSet of this.changeSets) {
+        await this.commitChangeSet(changeSet);
       }
     }
 
-    this.persistStack.length = 0;
+    this.clear(false);
   }
 
-  clear(): void {
-    Object.keys(this.identityMap).forEach(key => delete this.identityMap[key]);
+  clear(identityMap = true): void {
+    if (identityMap) {
+      Object.keys(this.identityMap).forEach(key => delete this.identityMap[key]);
+    }
+
+    Object.keys(this.identifierMap).forEach(key => delete this.identifierMap[key]);
+    this.persistStack.length = 0;
+    this.removeStack.length = 0;
+    this.changeSets.length = 0;
   }
 
   unsetIdentity(entity: IEntity): void {
     delete this.identityMap[`${entity.constructor.name}-${entity.id}`];
   }
 
-  private async computeChangeSet(entity: IEntity): Promise<ChangeSet | null> {
-    const ret = { entity } as ChangeSet;
-    const meta = this.metadata[entity.constructor.name];
+  computeChangeSets(): void {
+    this.changeSets.length = 0;
 
-    ret.name = meta.name;
-    ret.collection = meta.collection;
-
-    if (entity.id && this.identityMap[`${meta.name}-${entity.id}`]) {
-      ret.payload = Utils.diffEntities(this.identityMap[`${meta.name}-${entity.id}`], entity);
-    } else {
-      ret.payload = Utils.prepareEntity(entity);
+    while (this.persistStack.length) {
+      this.findNewEntities(this.persistStack.shift()!);
     }
 
-    this.em.validator.validate<typeof entity>(ret.entity, ret.payload, meta);
-    await this.processReferences(ret, meta);
+    for (const entity of Object.values(this.removeStack)) {
+      const meta = this.metadata[entity.constructor.name];
+      this.changeSets.push({ entity, delete: true, name: meta.name, collection: meta.collection, payload: {} } as ChangeSet);
+    }
+  }
 
-    if (entity.id && Object.keys(ret.payload).length === 0) {
+  computeChangeSet(entity: IEntity): ChangeSet | null {
+    const changeSet = { entity } as ChangeSet;
+    const meta = this.metadata[entity.constructor.name];
+
+    changeSet.name = meta.name;
+    changeSet.collection = meta.collection;
+
+    if (entity.id && this.identityMap[`${meta.name}-${entity.id}`]) {
+      changeSet.payload = Utils.diffEntities(this.identityMap[`${meta.name}-${entity.id}`], entity);
+    } else {
+      changeSet.payload = Utils.prepareEntity(entity);
+    }
+
+    this.em.validator.validate<typeof entity>(changeSet.entity, changeSet.payload, meta);
+    this.processReferences(changeSet, meta);
+
+    if (entity.id && Object.keys(changeSet.payload).length === 0) {
       return null;
     }
 
-    return ret;
+    this.changeSets.push(changeSet);
+    this.cleanUpStack(this.persistStack, entity);
+
+    return changeSet;
   }
 
-  private async processReferences(changeSet: ChangeSet, meta: EntityMetadata): Promise<void> {
+  private processReferences(changeSet: ChangeSet, meta: EntityMetadata): void {
     for (const prop of Object.values(meta.properties)) {
-      if (prop.reference === ReferenceType.ONE_TO_MANY) {
+      if (prop.reference === ReferenceType.MANY_TO_MANY && prop.owner) {
         const collection = changeSet.entity[prop.name] as Collection<IEntity>;
-        collection.setDirty(false);
-      } else if (prop.reference === ReferenceType.MANY_TO_MANY) {
-        await this.processManyToMany(changeSet, prop);
+
+        if (prop.owner && collection.isDirty()) {
+          const pk = this.metadata[prop.type].primaryKey as keyof IEntity;
+          changeSet.payload[prop.name] = collection.getItems().map(item => item[pk] || this.identifierMap[item.uuid]);
+          collection.setDirty(false);
+        }
       } else if (prop.reference === ReferenceType.MANY_TO_ONE && changeSet.entity[prop.name]) {
-        await this.processManyToOne(changeSet, prop);
-      }
-    }
-  }
+        const pk = this.metadata[prop.type].primaryKey;
+        const entity = changeSet.entity[prop.name];
 
-  private async processManyToOne(changeSet: ChangeSet, prop: EntityProperty): Promise<void> {
-    const pk = this.metadata[prop.type].primaryKey;
-
-    // when new entity found in reference, cascade persist it first so we have its id
-    if (!changeSet.entity[prop.name][pk]) {
-      const propChangeSet = await this.persist(changeSet.entity[prop.name]);
-      await this.immediateCommit(propChangeSet!);
-      changeSet.payload[prop.name] = changeSet.entity[prop.name][pk];
-    }
-  }
-
-  private async processManyToMany<T>(changeSet: ChangeSet, prop: EntityProperty): Promise<void> {
-    const collection = changeSet.entity[prop.name] as Collection<IEntity>;
-
-    if (prop.owner && collection.isDirty()) {
-      for (const item of collection.getItems()) {
-        const pk = this.metadata[prop.type].primaryKey as keyof typeof item;
-
-        // when new entity found in reference, cascade persist it first so we have its id
-        if (!item[pk]) {
-          const itemChangeSet = await this.persist(item);
-          await this.immediateCommit(itemChangeSet!);
+        if (!entity[pk]) {
+          changeSet.payload[prop.name] = this.identifierMap[entity.uuid];
         }
       }
-
-      const pk = this.metadata[prop.type].primaryKey;
-      changeSet.payload[prop.name] = collection.getIdentifiers(pk);
-      collection.setDirty(false);
     }
   }
 
-  private async immediateCommit(changeSet: ChangeSet, removeFromStack = true): Promise<void> {
+  private findNewEntities<T extends IEntityType<T>>(entity: T, visited: IEntity[] = []): void {
+    if (visited.includes(entity)) {
+      return;
+    }
+
+    const meta = this.metadata[entity.constructor.name] as EntityMetadata<T>;
+    visited.push(entity);
+
+    if (!entity.id && !this.identifierMap[entity.uuid]) {
+      this.identifierMap[entity.uuid] = new Identifier();
+    }
+
+    for (const prop of Object.values(meta.properties)) {
+      const reference = entity[prop.name as keyof T];
+
+      if (prop.reference === ReferenceType.MANY_TO_MANY) {
+        const collection = reference as Collection<IEntity>;
+
+        if (collection.isDirty()) {
+          for (const item of collection.getItems()) {
+            if (!this.hasIdentifier(item)) {
+              this.findNewEntities(item, visited);
+            }
+          }
+        }
+      } else if (prop.reference === ReferenceType.MANY_TO_ONE && reference) {
+        if (!this.hasIdentifier(reference)) {
+          this.findNewEntities(reference, visited);
+        }
+      }
+    }
+
+    this.computeChangeSet(entity);
+  }
+
+  private async commitChangeSet<T extends IEntityType<T>>(changeSet: ChangeSet<T>): Promise<void> {
     const meta = this.metadata[changeSet.name];
-    const pk = meta.primaryKey;
+    const pk = meta.primaryKey as keyof T;
     const type = changeSet.entity[pk] ? (changeSet.delete ? 'Delete' : 'Update') : 'Create';
     await this.runHooks(`before${type}`, changeSet.entity, changeSet.payload);
 
     // process references first
     for (const prop of Object.values(meta.properties)) {
+      const value = changeSet.payload[prop.name];
+
+      if (value instanceof Identifier) {
+        changeSet.payload[prop.name] = value.getValue();
+      } else if (Array.isArray(value) && value.some(item => item instanceof Identifier)) {
+        changeSet.payload[prop.name] = value.map(item => item instanceof Identifier ? item.getValue() : item);
+      }
+
       if (prop.onUpdate) {
-        changeSet.entity[prop.name] = changeSet.payload[prop.name] = prop.onUpdate();
+        changeSet.entity[prop.name as keyof T] = changeSet.payload[prop.name] = prop.onUpdate();
       }
     }
 
@@ -170,16 +211,13 @@ export class UnitOfWork {
       await this.em.getDriver().nativeUpdate(changeSet.name, changeSet.entity[pk], changeSet.payload);
       this.addToIdentityMap(changeSet.entity);
     } else {
-      changeSet.entity[pk] = await this.em.getDriver().nativeInsert(changeSet.name, changeSet.payload);
+      changeSet.entity[pk] = await this.em.getDriver().nativeInsert(changeSet.name, changeSet.payload) as T[keyof T];
+      this.identifierMap[changeSet.entity.uuid].setValue(changeSet.entity[pk]);
       delete changeSet.entity.__initialized;
       this.em.merge(changeSet.name, changeSet.entity);
     }
 
     await this.runHooks(`after${type}`, changeSet.entity);
-
-    if (removeFromStack) {
-      this.persistStack.splice(changeSet.index, 1);
-    }
   }
 
   private async runHooks<T extends IEntityType<T>>(type: string, entity: IEntityType<T>, payload?: EntityData<T>) {
@@ -198,13 +236,48 @@ export class UnitOfWork {
     }
   }
 
+  /**
+   * clean up persist/remove stack from previous persist/remove calls for this entity done before flushing
+   */
+  private cleanUpStack(stack: IEntity[], entity: IEntity) {
+    for (const index in stack) {
+      if (stack[index] === entity) {
+        stack.splice(+index, 1);
+      }
+    }
+  }
+
+  private hasIdentifier<T extends IEntityType<T>>(entity: T): boolean {
+    const pk = this.metadata[entity.constructor.name].primaryKey as keyof T;
+
+    if (entity[pk]) {
+      return true;
+    }
+
+    return this.identifierMap[entity.uuid] && this.identifierMap[entity.uuid].getValue();
+  }
+
 }
 
-export interface ChangeSet<T extends IEntityType<T> = any> {
+export interface ChangeSet<T extends IEntityType<T> = IEntityType<any>> {
   index: number;
   name: string;
   collection: string;
   delete: boolean;
   entity: T;
   payload: EntityData<T>;
+}
+
+export class Identifier {
+
+  constructor(private value?: IPrimaryKey) { }
+
+  setValue(value: IPrimaryKey): void {
+    this.value = value;
+  }
+
+  getValue<T = IPrimaryKey>(): T {
+    return this.value as T;
+  }
+
 }

--- a/lib/UnitOfWork.ts
+++ b/lib/UnitOfWork.ts
@@ -58,11 +58,10 @@ export class UnitOfWork {
 
     if (entity.id) {
       this.removeStack.push(entity);
-    } else {
-      delete this.identifierMap[entity.uuid];
     }
 
     this.cleanUpStack(this.persistStack, entity);
+    this.unsetIdentity(entity);
   }
 
   async commit(): Promise<void> {

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -31,6 +31,7 @@ export interface IEntity<K = number | string> {
   toObject(parent?: IEntity, isCollection?: boolean): { [field: string]: any };
   toJSON(): { [field: string]: any };
   assign(data: any): void;
+  uuid: string;
   __em: EntityManager;
   __initialized?: boolean;
   __populated: boolean;

--- a/lib/utils/EntityHelper.ts
+++ b/lib/utils/EntityHelper.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { Collection } from '../Collection';
 import { SCALAR_TYPES } from '../EntityFactory';
 import { EntityManager } from '../EntityManager';
@@ -83,7 +84,7 @@ export class EntityHelper {
 
   private static assignReference<T extends IEntityType<T>>(entity: T, value: any, prop: EntityProperty, em: EntityManager): void {
     if (Utils.isEntity(value)) {
-      entity[prop.name as keyof T] = value;
+      entity[prop.name as keyof T] = value as T[keyof T];
       return;
     }
 
@@ -112,6 +113,8 @@ export class EntityHelper {
       }
 
       invalid.push(item);
+
+      return item;
     });
 
     if (invalid.length > 0) {
@@ -160,6 +163,20 @@ export class EntityHelper {
         value(parent?: IEntity, isCollection?: boolean) {
           return EntityHelper.toObject(this, parent, isCollection);
         }
+      },
+      uuid: {
+        get(): string {
+          if (!this.__uuid) {
+            Object.defineProperty(this, '__uuid', {
+              value: uuid(),
+              enumerable: false,
+              writable: false,
+              configurable: false,
+            });
+          }
+
+          return this.__uuid;
+        },
       },
     });
 

--- a/lib/utils/EntityIdentifier.ts
+++ b/lib/utils/EntityIdentifier.ts
@@ -1,0 +1,15 @@
+import { IPrimaryKey } from '..';
+
+export class EntityIdentifier {
+
+  constructor(private value?: IPrimaryKey) { }
+
+  setValue(value: IPrimaryKey): void {
+    this.value = value;
+  }
+
+  getValue<T = IPrimaryKey>(): T {
+    return this.value as T;
+  }
+
+}

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -110,7 +110,7 @@ export class Utils {
     return result;
   }
 
-  static isPrimaryKey(key: any): boolean {
+  static isPrimaryKey(key: any): key is IPrimaryKey {
     return typeof key === 'string' || typeof key === 'number' || Utils.isObjectID(key);
   }
 

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -126,7 +126,7 @@ export class Utils {
     return null;
   }
 
-  static isEntity(data: any): boolean {
+  static isEntity<T = IEntity>(data: any): data is T {
     return Utils.isObject(data) && !!data.__entity;
   }
 

--- a/package.json
+++ b/package.json
@@ -60,22 +60,22 @@
     "fast-deep-equal": "^2.0.1",
     "lodash.merge": "^4.6.1",
     "node-request-context": "^1.0.5",
-    "ts-morph": "^1.0.0",
+    "ts-morph": "^1.2.0",
     "typescript": "^3.3.3",
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
     "mongodb": "^3.1.13",
     "mysql2": "^1.6.5",
-    "sqlite": "^3.0.1"
+    "sqlite": "^3.0.2"
   },
   "devDependencies": {
     "@types/clone": "^0.1.30",
-    "@types/jest": "^24.0.1",
-    "@types/lodash": "^4.14.120",
+    "@types/jest": "^24.0.6",
+    "@types/lodash": "^4.14.121",
     "@types/mongodb": "^3.1.19",
     "@types/mysql2": "types/mysql2",
-    "@types/node": "^11.9.0",
+    "@types/node": "^11.9.4",
     "@types/uuid": "^3.4.4",
     "codacy-coverage": "^3.4.0",
     "coveralls": "^3.0.2",
@@ -84,8 +84,8 @@
     "mysql2": "^1.6.5",
     "pre-commit": "^1.2.2",
     "rimraf": "^2.6.3",
-    "sqlite": "^3.0.0",
-    "ts-jest": "^23.10.5",
+    "sqlite": "^3.0.2",
+    "ts-jest": "^24.0.0",
     "ts-node": "^8.0.2",
     "tslint": "^5.12.1"
   }

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -170,11 +170,11 @@ describe('EntityManagerMongo', () => {
     const author = new Author('name', 'email');
     const repo = orm.em.getRepository(Author) as AuthorRepository;
     await repo.persist(author);
-    expect(orm.em.getIdentity(Author, author.id)).toBeDefined();
+    expect(orm.em.getUnitOfWork().getById(Author.name, author.id)).toBeDefined();
     author.name = 'new name';
     await repo.persist(author, false);
     await orm.em.removeEntity(author);
-    expect(orm.em.getIdentity(Author, author.id)).toBeUndefined();
+    expect(orm.em.getUnitOfWork().getById(Author.name, author.id)).toBeUndefined();
     expect(orm.em.getIdentityMap()).toEqual({});
   });
 

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -458,11 +458,11 @@ describe('EntityManagerMySql', () => {
     expect(book.tags.count()).toBe(1);
 
     // add
-    book.tags.add(tag1);
+    book.tags.add(tag1, new BookTag2('fresh'));
     await orm.em.persist(book);
     orm.em.clear();
     book = (await orm.em.findOne(Book2, book.id, ['tags']))!;
-    expect(book.tags.count()).toBe(2);
+    expect(book.tags.count()).toBe(3);
 
     // contains
     expect(book.tags.contains(tag1)).toBe(true);

--- a/tests/RequestContext.test.ts
+++ b/tests/RequestContext.test.ts
@@ -16,7 +16,8 @@ describe('RequestContext', () => {
     RequestContext.create(orm.em, () => {
       const em = RequestContext.getEntityManager()!;
       expect(em).not.toBe(orm.em);
-      expect(em['_unitOfWork']['identityMap']).not.toBe(orm.em['_unitOfWork']['identityMap']);
+      // access UoW via property so we do not get the one from request context automatically
+      expect(em['unitOfWork'].getIdentityMap()).not.toBe(orm.em['unitOfWork'].getIdentityMap());
     });
   });
 

--- a/tests/RequestContext.test.ts
+++ b/tests/RequestContext.test.ts
@@ -16,7 +16,7 @@ describe('RequestContext', () => {
     RequestContext.create(orm.em, () => {
       const em = RequestContext.getEntityManager()!;
       expect(em).not.toBe(orm.em);
-      expect(em['identityMap']).not.toBe(orm.em['identityMap']);
+      expect(em['_unitOfWork']['identityMap']).not.toBe(orm.em['_unitOfWork']['identityMap']);
     });
   });
 

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -77,6 +77,9 @@ describe('UnitOfWork', () => {
     uow.addToIdentityMap(author); // add entity to IM first
     const changeSet = await uow.computeChangeSet(author); // then try to persist it again
     expect(changeSet).toBeNull();
+    expect(uow.getIdentityMap()).not.toEqual({});
+    uow.clear();
+    expect(uow.getIdentityMap()).toEqual({});
   });
 
   test('persist and remove will add entity to given stack only once', async () => {

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -21,19 +21,19 @@ describe('UnitOfWork', () => {
     // number instead of string will throw
     const author = new Author('test', 'test');
     Object.assign(author, { name: 111, email: 222 });
-    await expect(uow.persist(author)).rejects.toThrowError(`Validation error: trying to set Author.name of type 'string' to '111' of type 'number'`);
+    expect(() => uow.computeChangeSet(author)).toThrowError(`Validation error: trying to set Author.name of type 'string' to '111' of type 'number'`);
 
     // string date with unknown format will throw
     Object.assign(author, { name: '333', email: '444', born: 'asd' });
-    await expect(uow.persist(author)).rejects.toThrowError(`Validation error: trying to set Author.born of type 'date' to 'asd' of type 'string'`);
+    expect(() => uow.computeChangeSet(author)).toThrowError(`Validation error: trying to set Author.born of type 'date' to 'asd' of type 'string'`);
 
     // number bool with other value than 0/1 will throw
     Object.assign(author, { termsAccepted: 2 });
-    await expect(uow.persist(author)).rejects.toThrowError(`Validation error: trying to set Author.termsAccepted of type 'boolean' to '2' of type 'number'`);
+    expect(() => uow.computeChangeSet(author)).toThrowError(`Validation error: trying to set Author.termsAccepted of type 'boolean' to '2' of type 'number'`);
 
     // string date with correct format will be auto-corrected
     Object.assign(author, { name: '333', email: '444', born: '2018-01-01', termsAccepted: 1 });
-    let changeSet = (await uow.persist(author))!;
+    let changeSet = uow.computeChangeSet(author)!;
     expect(typeof changeSet.payload.name).toBe('string');
     expect(changeSet.payload.name).toBe('333');
     expect(typeof changeSet.payload.email).toBe('string');
@@ -44,56 +44,53 @@ describe('UnitOfWork', () => {
 
     // Date object will be ok
     Object.assign(author, { born: new Date() });
-    changeSet = (await uow.persist(author))!;
+    changeSet = (await uow.computeChangeSet(author))!;
     expect(changeSet.payload.born instanceof Date).toBe(true);
 
     // null will be ok
     Object.assign(author, { born: null });
-    changeSet = (await uow.persist(author))!;
+    changeSet = (await uow.computeChangeSet(author))!;
     expect(changeSet.payload.born).toBeNull();
 
     // string number with correct format will be auto-corrected
     Object.assign(author, { age: '21' });
-    changeSet = (await uow.persist(author))!;
+    changeSet = (await uow.computeChangeSet(author))!;
     expect(typeof changeSet.payload.age).toBe('number');
     expect(changeSet.payload.age).toBe(21);
 
     // string instead of number with will throw
     Object.assign(author, { age: 'asd' });
-    await expect(uow.persist(author)).rejects.toThrowError(`Validation error: trying to set Author.age of type 'number' to 'asd' of type 'string'`);
+    expect(() => uow.computeChangeSet(author)).toThrowError(`Validation error: trying to set Author.age of type 'number' to 'asd' of type 'string'`);
     Object.assign(author, { age: new Date() });
-    await expect(uow.persist(author)).rejects.toThrowError(/Validation error: trying to set Author\.age of type 'number' to '.*' of type 'date'/);
+    expect(() => uow.computeChangeSet(author)).toThrowError(/Validation error: trying to set Author\.age of type 'number' to '.*' of type 'date'/);
     Object.assign(author, { age: false });
-    await expect(uow.persist(author)).rejects.toThrowError(`Validation error: trying to set Author.age of type 'number' to 'false' of type 'boolean'`);
+    expect(() => uow.computeChangeSet(author)).toThrowError(`Validation error: trying to set Author.age of type 'number' to 'false' of type 'boolean'`);
 
     // missing collection instance in m:n and 1:m relations
     delete author.books;
-    await expect(uow.persist(author)).rejects.toThrowError(`Validation error: Author.books is not initialized, define it as 'books = new Collection<Book>(this);'`);
+    expect(() => uow.computeChangeSet(author)).toThrowError(`Validation error: Author.books is not initialized, define it as 'books = new Collection<Book>(this);'`);
   });
 
   test('changeSet is null for empty payload', async () => {
     const author = new Author('test', 'test');
     author.id = '00000001885f0a3cc37dc9f0';
     uow.addToIdentityMap(author); // add entity to IM first
-    const changeSet = await uow.persist(author); // then try to persist it again
+    const changeSet = await uow.computeChangeSet(author); // then try to persist it again
     expect(changeSet).toBeNull();
   });
 
-  test('changeSet is null when persisting twice', async () => {
+  test('persist and remove will add entity to given stack only once', async () => {
     const author = new Author('test', 'test');
     author.id = '00000001885f0a3cc37dc9f0';
-    const changeSet1 = await uow.persist(author);
-    expect(changeSet1).not.toBeNull();
-    const changeSet2 = await uow.persist(author);
-    expect(changeSet2).toBeNull();
-  });
-
-  test('commit runs everything in transaction', async () => {
-    const author = new Author('test', 'test');
-    author.id = '00000001885f0a3cc37dc9f0';
-    await uow.persist(author);
-    uow['persistStack'][0].payload = 'foo-bar' as any; // make it rollback
-    await expect(uow.commit()).rejects.toThrow();
+    uow.persist(author);
+    expect(uow['persistStack'].length).toBe(1);
+    uow.persist(author);
+    expect(uow['persistStack'].length).toBe(1);
+    uow.remove(author);
+    expect(uow['persistStack'].length).toBe(0);
+    expect(uow['removeStack'].length).toBe(1);
+    uow.remove(author);
+    expect(uow['removeStack'].length).toBe(1);
   });
 
   afterAll(async () => orm.close(true));

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -13,13 +13,13 @@ export class Book2 extends BaseEntity2 {
   @Property()
   title: string;
 
-  @ManyToOne()
+  @ManyToOne({ cascade: [] })
   author: Author2;
 
-  @ManyToOne()
+  @ManyToOne({ cascade: [] })
   publisher: Publisher2;
 
-  @ManyToMany({ entity: () => BookTag2.name, inversedBy: 'books' })
+  @ManyToMany({ entity: () => BookTag2.name, inversedBy: 'books', cascade: [] })
   tags: Collection<BookTag2>;
 
   constructor(title: string, author: Author2) {


### PR DESCRIPTION
- [x] wrap primary keys in payload with Identifier class
- [x] introduce IEntity.uuid so we have unique identifier for each entity even if we do not have PK
- [x] always run queries inside transaction (when supported by given driver)
- [x] postpone inserts of new entities to commit
- [x] make UoW persist API sync (only commit is async now as only commit writes to database)
- [x] move identity map to UoW, store copies for diffing in `originalEntityData` map
- [x] remove identity map API from entity manager