### PR TITLE
Allow configuring array of entities via `entities` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,14 @@ Then call `MikroORM.init` as part of bootstrapping your app:
 ```typescript
 const orm = await MikroORM.init({
   entitiesDirs: ['./dist/entities'], // path to your JS entities (dist), relative to `baseDir`
-  entitiesDirsTs: ['./src/entities'], // path to your TS entities (source), relative to `baseDir`
   dbName: 'my-db-name',
   clientUrl: '...', // defaults to 'mongodb://localhost:27017' for mongodb driver
 });
 console.log(orm.em); // access EntityManager via `em` property
 ```
 
-> Unless you are using `ts-node`, you will need to provide path to both compiled JS and 
-> source TS folders. This is needed for reflection that will sniff types from TS files in 
-> the background. 
+There are more ways to configure your entities, take a look at 
+[installation page](https://b4nan.github.io/mikro-orm/identity-map/#request-context).
 
 Then you will need to fork entity manager for each request so their 
 [identity maps](https://b4nan.github.io/mikro-orm/identity-map/) will not collide. 

--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,7 @@
 
 - postgres driver
 - schema generator for SQL drivers
-- debugging section in docs (add logger, set debug mode, query logger)
 - test request context is properly garbage collected or we need some clean manual up
 - single table inheritance
 - implement transactions in mongo driver
 - use bulk inserts/deletes in mongo driver (insertMany/deleteMany) when flushing
-- adopt commitizen to have automatic changelog (http://commitizen.github.io/cz-cli/)

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,31 @@
+# Debugging
+
+For development purposes it might come handy to enable logging and debug mode:
+
+```typescript
+return MikroORM.init({
+  logger: console.log.bind(console),
+  debug: true,
+});
+```
+
+By doing this `MikroORM` will start using provided logger function to dump all queries:
+
+```
+[query-logger] SELECT `e0`.* FROM `author` AS `e0` WHERE `e0`.`name` = ? LIMIT ? [took 2 ms]
+[query-logger] START TRANSACTION [took 1 ms]
+[query-logger] INSERT INTO `author` (`name`, `email`, `created_at`, `updated_at`, `terms_accepted`) VALUES (?, ?, ?, ?, ?) [took 2 ms]
+[query-logger] COMMIT [took 2 ms]
+```
+
+It is also useful for debugging problems with entity discovery, as you will see information
+about every processed entity:
+
+```
+ORM entity discovery started
+- processing entity Author
+- using cached metadata for entity Author
+- processing entity Book
+- processing entity BookTag
+- entity discovery finished after 13 ms
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,8 @@ Heavily inspired by [Doctrine](https://www.doctrine-project.org/) and [Nextras O
   - [Property validation](property-validation.md)
   - [Lifecycle hooks](lifecycle-hooks.md)
   - [Naming strategy](naming-strategy.md)
+  - [Metadata cache](metadata-cache.md)
+  - [Debugging](debugging.md)
 - Usage with different drivers
   - [Usage with MySQL and SQLite](usage-with-sql.md)
   - [Usage with MongoDB](usage-with-mongo.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,8 +31,7 @@ Then call `MikroORM.init` as part of bootstrapping your app:
 
 ```typescript
 const orm = await MikroORM.init({
-  entitiesDirs: ['./dist/entities'], // path to your JS entities (dist), relative to `baseDir`
-  entitiesDirsTs: ['./src/entities'], // path to your TS entities (source), relative to `baseDir`
+  entities: [Author, Book, BookTag],
   dbName: 'my-db-name',
   clientUrl: '...', // defaults to 'mongodb://localhost:27017' for mongodb driver
   baseDir: __dirname, // defaults to `process.cwd()`
@@ -40,9 +39,43 @@ const orm = await MikroORM.init({
 console.log(orm.em); // access EntityManager via `em` property
 ```
 
-> Unless you are using `ts-node`, you will need to provide path to both compiled JS and 
-> source TS folders. This is needed for reflection that will sniff types from TS files in 
-> the background. 
+You can also provide paths where you store your entities via `entitiesDirs` array. Internally
+it uses [`globby`](https://github.com/sindresorhus/globby) so you can use 
+[globbing patterns](https://github.com/sindresorhus/globby#globbing-patterns). 
+
+```typescript
+const orm = await MikroORM.init({
+  entitiesDirs: ['./dist/app/**/entities'],
+  // ...
+});
+```
+
+You should provide list of directories, not paths to entities directly. If you want to do that
+instead, you should use `entities` array and use `globby` manually:
+
+```typescript
+import { sync } from 'globby';
+
+const orm = await MikroORM.init({
+  entities: sync('./dist/app/**/entities/*.js').map(require),
+  // ...
+});
+```
+
+## Entity discovery in TypeScript
+
+Internally, `MikroORM` uses [performs analysis](metadata-cache.md) of source files of entities 
+to sniff types of all properties. This process can be slow if your project contains lots of 
+files. To speed up the discovery process a bit, you can provide more accurate paths where your
+entity source files are: 
+
+```typescript
+const orm = await MikroORM.init({
+  entitiesDirs: ['./dist/entities'], // path to your JS entities (dist), relative to `baseDir`
+  entitiesDirsTs: ['./src/entities'], // path to your TS entities (source), relative to `baseDir`
+  // ...
+});
+```
 
 Then you will need to fork entity manager for each request so their identity maps will not 
 collide. To do so, use the `RequestContext` helper:

--- a/docs/metadata-cache.md
+++ b/docs/metadata-cache.md
@@ -1,0 +1,71 @@
+# Metadata cache
+
+Under the hood, `MikroORM` uses [`ts-morph`](https://github.com/dsherret/ts-morph) to read 
+TypeScript source files of all entities to be able to detect all types. Thanks to this, 
+defining the type is enough for runtime validation.
+
+This process can be a bit slow, mainly because `ts-morph` will scan all your source files
+based on your `tsconfig.json`. You can speed up this process by whitelisting only the folders
+where your entities are via `entitiesDirsTs` option. 
+
+After the discovery process ends, all metadata will be cached. By default, `FileCacheAdapter`
+will be used to store the cache inside `./temp` folder to JSON files. 
+
+## Automatic invalidation
+
+Entity metadata are cached together with modified time of the source file, and every time
+the cache is requested, it first checks if the cache is not invalid. This way you can forgot 
+about the caching mechanism most of the time.
+
+One case where you can end up needing to wipe the cache manually is when you work withing a 
+git branch where contents of entities folder differs. 
+
+## Disabling metadata cache
+
+You can disable caching via:
+
+```typescript
+await MikroORM.init({
+  cache: { enabled: false },
+  // ...
+});
+```
+
+## Using different temp folder
+
+You can set the temp folder via:
+
+```typescript
+await MikroORM.init({
+  cache: { options: { cacheDir: '...' } },
+  // ...
+});
+```
+
+## Providing custom cache adapter
+
+You can also implement your own cache adapter, for example to store the cache in redis. 
+To do so, just implement simple `CacheAdapter` interface:
+
+```typescript
+export interface CacheAdapter {
+
+  get(name: string): any;
+
+  set(name: string, data: any, origin: string): void;
+
+}
+```
+
+```typescript
+export class RedisCacheAdapter implements CacheAdapter { ... }
+```
+
+And provide the implementation in `cache.adapter` option:
+
+```typescript
+await MikroORM.init({
+  cache: { adapter: RedisCacheAdapter, options: { ... } },
+  // ...
+});
+```

--- a/lib/MikroORM.ts
+++ b/lib/MikroORM.ts
@@ -10,6 +10,7 @@ import { TypeScriptMetadataProvider } from './metadata/TypeScriptMetadataProvide
 import { MetadataProvider } from './metadata/MetadataProvider';
 import { EntityRepository } from './EntityRepository';
 import { EntityClass, IEntity } from './decorators/Entity';
+import { NullCacheAdapter } from './cache/NullCacheAdapter';
 
 const defaultOptions = {
   entitiesDirs: [],
@@ -65,6 +66,10 @@ export class MikroORM {
 
     if (!this.options.driver) {
       this.options.driver = require('./drivers/MongoDriver').MongoDriver;
+    }
+
+    if (!this.options.cache.enabled) {
+      this.options.cache.adapter = NullCacheAdapter;
     }
 
     this.logger = new Logger(this.options);

--- a/lib/MikroORM.ts
+++ b/lib/MikroORM.ts
@@ -13,6 +13,8 @@ import { EntityClass, IEntity } from './decorators/Entity';
 
 const defaultOptions = {
   entitiesDirs: [],
+  entitiesDirsTs: [],
+  tsConfigPath: process.cwd() + '/tsconfig.json',
   autoFlush: true,
   strict: false,
   logger: () => undefined,
@@ -94,7 +96,8 @@ export class MikroORM {
 export interface MikroORMOptions {
   dbName: string;
   entitiesDirs: string[];
-  entitiesDirsTs?: string[];
+  entitiesDirsTs: string[];
+  tsConfigPath: string;
   autoFlush: boolean;
   driver?: { new (options: MikroORMOptions, logger: Logger): IDatabaseDriver };
   namingStrategy?: { new (): NamingStrategy };

--- a/lib/MikroORM.ts
+++ b/lib/MikroORM.ts
@@ -13,6 +13,7 @@ import { EntityClass, IEntity } from './decorators/Entity';
 import { NullCacheAdapter } from './cache/NullCacheAdapter';
 
 const defaultOptions = {
+  entities: [],
   entitiesDirs: [],
   entitiesDirsTs: [],
   tsConfigPath: process.cwd() + '/tsconfig.json',
@@ -60,8 +61,8 @@ export class MikroORM {
       throw new Error('No database specified, please fill in `dbName` option');
     }
 
-    if (!this.options.entitiesDirs || this.options.entitiesDirs.length === 0) {
-      throw new Error('No directories for entity discovery specified, please fill in `entitiesDirs` option');
+    if (this.options.entities.length === 0 && this.options.entitiesDirs.length === 0) {
+      throw new Error('No entities found, please use `entities` or `entitiesDirs` option');
     }
 
     if (!this.options.driver) {
@@ -100,6 +101,7 @@ export class MikroORM {
 
 export interface MikroORMOptions {
   dbName: string;
+  entities: EntityClass<IEntity>[];
   entitiesDirs: string[];
   entitiesDirsTs: string[];
   tsConfigPath: string;

--- a/lib/cache/NullCacheAdapter.ts
+++ b/lib/cache/NullCacheAdapter.ts
@@ -1,0 +1,13 @@
+import { CacheAdapter } from './CacheAdapter';
+
+export class NullCacheAdapter implements CacheAdapter {
+
+  get(name: string): any {
+    return null;
+  }
+
+  set(name: string, data: any, origin: string): void {
+    // ignore
+  }
+
+}

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -12,6 +12,7 @@ export function Entity(options: EntityOptions = {}): Function {
     meta.name = target.name;
     meta.constructorParams = Utils.getParamNames(target);
     meta.extends = Object.getPrototypeOf(target).name || undefined;
+    Utils.lookupPathFromDecorator(meta);
 
     return target;
   };
@@ -40,9 +41,7 @@ export type IEntityType<T> = {
   [k in keyof T]: IEntity | Collection<IEntity> | any;
 } & IEntity;
 
-export type EntityClass<T extends IEntityType<T>> = {
-  new(...args: any[]): T;
-}
+export type EntityClass<T extends IEntityType<T>> = Function & { prototype: T };
 
 export type EntityData<T extends IEntityType<T>> = {
   [P in keyof T]?: T[P] | IPrimaryKey;

--- a/lib/decorators/ManyToMany.ts
+++ b/lib/decorators/ManyToMany.ts
@@ -1,11 +1,13 @@
 import { PropertyOptions } from './Property';
 import { Cascade, EntityProperty, IEntity, ReferenceType } from './Entity';
 import { MetadataStorage } from '../metadata/MetadataStorage';
+import { Utils } from '../utils/Utils';
 
 export function ManyToMany(options: ManyToManyOptions): Function {
   return function (target: IEntity, propertyName: string) {
     const entity = target.constructor.name;
     const meta = MetadataStorage.getMetadata(entity);
+    Utils.lookupPathFromDecorator(meta);
 
     if (!options.entity) {
       throw new Error(`'@ManyToMany({ entity: string | Function })' is required in '${target.constructor.name}.${propertyName}'`);

--- a/lib/decorators/ManyToOne.ts
+++ b/lib/decorators/ManyToOne.ts
@@ -1,10 +1,12 @@
 import { PropertyOptions } from './Property';
 import { Cascade, EntityProperty, IEntity, ReferenceType } from './Entity';
 import { MetadataStorage } from '../metadata/MetadataStorage';
+import { Utils } from '../utils/Utils';
 
 export function ManyToOne(options: ManyToOneOptions = {}): Function {
   return function (target: IEntity, propertyName: string) {
     const meta = MetadataStorage.getMetadata(target.constructor.name);
+    Utils.lookupPathFromDecorator(meta);
     const property = { name: propertyName, reference: ReferenceType.MANY_TO_ONE, cascade: [Cascade.PERSIST] };
     meta.properties[propertyName] = Object.assign(property, options) as EntityProperty;
   };

--- a/lib/decorators/OneToMany.ts
+++ b/lib/decorators/OneToMany.ts
@@ -1,10 +1,12 @@
 import { PropertyOptions } from './Property';
 import { Cascade, EntityProperty, IEntity, ReferenceType } from './Entity';
 import { MetadataStorage } from '../metadata/MetadataStorage';
+import { Utils } from '../utils/Utils';
 
 export function OneToMany(options: OneToManyOptions): Function {
   return function (target: IEntity, propertyName: string) {
     const meta = MetadataStorage.getMetadata(target.constructor.name);
+    Utils.lookupPathFromDecorator(meta);
 
     if (!options.entity) {
       throw new Error(`'@OneToMany({ entity: string | Function })' is required in '${target.constructor.name}.${propertyName}'`);

--- a/lib/decorators/PrimaryKey.ts
+++ b/lib/decorators/PrimaryKey.ts
@@ -1,5 +1,6 @@
 import { MetadataStorage } from '../metadata/MetadataStorage';
 import { EntityProperty, IEntity, ReferenceType } from './Entity';
+import { Utils } from '../utils/Utils';
 
 export function PrimaryKey(options: PrimaryKeyOptions = {}): Function {
   return function (target: IEntity, propertyName: string) {
@@ -7,6 +8,7 @@ export function PrimaryKey(options: PrimaryKeyOptions = {}): Function {
     options.name = propertyName;
     meta.primaryKey = propertyName;
     meta.properties[propertyName] = Object.assign({ reference: ReferenceType.SCALAR, primary: true }, options) as EntityProperty;
+    Utils.lookupPathFromDecorator(meta);
   };
 }
 

--- a/lib/decorators/Property.ts
+++ b/lib/decorators/Property.ts
@@ -1,9 +1,11 @@
 import { EntityProperty, IEntity, ReferenceType } from './Entity';
 import { MetadataStorage } from '../metadata/MetadataStorage';
+import { Utils } from '../utils/Utils';
 
 export function Property(options: PropertyOptions = {}): Function {
   return function (target: IEntity, propertyName: string) {
     const meta = MetadataStorage.getMetadata(target.constructor.name);
+    Utils.lookupPathFromDecorator(meta);
     options.name = propertyName;
     meta.properties[propertyName] = Object.assign({ reference: ReferenceType.SCALAR }, options) as EntityProperty;
   };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,7 @@ export * from './naming-strategy/UnderscoreNamingStrategy';
 export * from './metadata/MetadataProvider';
 export * from './metadata/JavaScriptMetadataProvider';
 export * from './metadata/TypeScriptMetadataProvider';
+export * from './cache/CacheAdapter';
 export { Cascade, Entity, IEntity, EntityOptions } from './decorators/Entity';
 export * from './decorators/OneToMany';
 export * from './decorators/ManyToOne';

--- a/lib/metadata/MetadataStorage.ts
+++ b/lib/metadata/MetadataStorage.ts
@@ -1,5 +1,4 @@
-import { readdirSync } from 'fs';
-import { join } from 'path';
+import { sync as globby } from 'globby';
 
 import { EntityClass, EntityMetadata, EntityProperty, IEntity, ReferenceType } from '../decorators/Entity';
 import { Utils } from '../utils/Utils';
@@ -62,7 +61,7 @@ export class MetadataStorage {
   }
 
   private discoverDirectory(basePath: string): string[] {
-    const files = readdirSync(join(this.options.baseDir, basePath));
+    const files = globby('*', { cwd: `${this.options.baseDir}/${basePath}` });
     this.logger.debug(`- processing ${files.length} files from directory ${basePath}`);
 
     const discovered: string[] = [];

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -4,7 +4,7 @@ import * as clone from 'clone';
 import { IEntity, IPrimaryKey } from '..';
 import { Collection } from '../Collection';
 import { MetadataStorage } from '../metadata/MetadataStorage';
-import { IEntityType } from '../decorators/Entity';
+import { EntityMetadata, IEntityType } from '../decorators/Entity';
 
 export class Utils {
 
@@ -165,6 +165,23 @@ export class Utils {
     }
 
     return classOrName.name;
+  }
+
+  /**
+   * uses some dark magic to get source path to caller where decorator is used
+   */
+  static lookupPathFromDecorator(meta: EntityMetadata): void {
+    if (meta.path) {
+      return;
+    }
+
+    // use some dark magic to get source path to caller
+    const stack = new Error().stack!.split('\n');
+    const line = stack.find(line => line.includes('__decorate'))!;
+
+    if (line) {
+      meta.path = line.match(/\((.*):\d+:\d+\)/)![1];
+    }
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "clone": "^2.1.2",
     "fast-deep-equal": "^2.0.1",
+    "globby": "^9.1.0",
     "node-request-context": "^1.0.5",
     "ts-morph": "^1.2.0",
     "typescript": "^3.3.3",
@@ -88,6 +89,7 @@
     "@commitlint/cli": "^7.5.2",
     "@commitlint/config-conventional": "^7.5.0",
     "@types/clone": "^0.1.30",
+    "@types/globby": "^8.0.0",
     "@types/jest": "^24.0.9",
     "@types/mongodb": "^3.1.19",
     "@types/mysql2": "types/mysql2",

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -1,6 +1,8 @@
 import { MikroORM } from '../lib';
 import { initORMMySql, wipeDatabaseMySql } from './bootstrap';
 import { Author2, Book2, BookTag2 } from './entities-sql';
+import { MetadataStorage } from '../lib/metadata/MetadataStorage';
+import { Logger } from '../lib/utils/Logger';
 
 /**
  * @class EntityHelperMySqlTest
@@ -9,7 +11,11 @@ describe('EntityHelperMySql', () => {
 
   let orm: MikroORM;
 
-  beforeAll(async () => orm = await initORMMySql());
+  beforeAll(async () => {
+    orm = await initORMMySql();
+    const logger = new Logger({ logger: jest.fn() } as any);
+    new MetadataStorage(orm.em, orm.options, logger).discover();
+  });
   beforeEach(async () => wipeDatabaseMySql(orm.em));
 
   test('#assign() should update entity values [mysql]', async () => {

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -1,4 +1,7 @@
 import { MikroORM, EntityManager } from '../lib';
+import { Author } from './entities';
+import { BASE_DIR } from './bootstrap';
+import { FooBaz2 } from './entities-sql/FooBaz2';
 
 /**
  * @class MikroORMTest
@@ -7,13 +10,16 @@ describe('MikroORM', () => {
 
   test('should throw when not enough options provided', async () => {
     expect(() => new MikroORM({ entitiesDirs: ['entities'], dbName: '' })).toThrowError('No database specified, please fill in `dbName` option');
-    expect(() => new MikroORM({ entitiesDirs: [], dbName: 'test' })).toThrowError('No directories for entity discovery specified, please fill in `entitiesDirs` option');
+    expect(() => new MikroORM({ entities: [], entitiesDirs: [], dbName: 'test' })).toThrowError('No entities found, please use `entities` or `entitiesDirs` option');
+    expect(() => new MikroORM({ dbName: 'test', entities: [Author], clientUrl: 'test' })).not.toThrowError();
     expect(() => new MikroORM({ dbName: 'test', entitiesDirs: ['entities'], clientUrl: 'test' })).not.toThrowError();
   });
 
   test('should throw when TS entity directory does not exist', async () => {
-    const error = /Path .*\/entities-invalid does not exist/;
-    await expect(MikroORM.init({ dbName: 'test', entitiesDirs: ['entities'], entitiesDirsTs: ['entities-invalid'] })).rejects.toThrowError(error);
+    let error = /Path .*\/entities-invalid does not exist/;
+    await expect(MikroORM.init({ dbName: 'test', baseDir: BASE_DIR, entities: [FooBaz2], cache: { enabled: false }, entitiesDirsTs: ['entities-invalid'] })).rejects.toThrowError(error);
+    error = /Source file for entity .* not found, check your 'entitiesDirsTs' option/;
+    await expect(MikroORM.init({ dbName: 'test', baseDir: BASE_DIR, entities: [FooBaz2], cache: { enabled: false }, entitiesDirsTs: ['entities'] })).rejects.toThrowError(error);
   });
 
   test('should init itself with entity manager', async () => {

--- a/tests/NullCacheAdapter.test.ts
+++ b/tests/NullCacheAdapter.test.ts
@@ -1,0 +1,16 @@
+import { NullCacheAdapter } from '../lib/cache/NullCacheAdapter';
+import { TEMP_DIR } from './bootstrap';
+
+/**
+ * @class FileCacheAdapterTest
+ */
+describe('NullCacheAdapter', () => {
+
+  test('should ignore old cache', async () => {
+    const origin = TEMP_DIR + '/.origin';
+    const cache = new NullCacheAdapter();
+    cache.set('cache-test-handle', 123, origin);
+    expect(cache.get('cache-test-handle')).toBeNull();
+  });
+
+});

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -5,6 +5,9 @@ import { MySqlDriver } from '../lib/drivers/MySqlDriver';
 import { SqliteDriver } from '../lib/drivers/SqliteDriver';
 import { MySqlConnection } from '../lib/connections/MySqlConnection';
 import { SqliteConnection } from '../lib/connections/SqliteConnection';
+import { BaseEntity2 } from './entities-sql/BaseEntity2';
+import { FooBar2 } from './entities-sql/FooBar2';
+import { BaseEntity22 } from './entities-sql/BaseEntity22';
 
 const { Author3 } = require('./entities-js/Author3');
 const { Book3 } = require('./entities-js/Book3');
@@ -38,7 +41,8 @@ export async function initORMMySql() {
   }
 
   const orm = await MikroORM.init({
-    entitiesDirs: ['entities-sql'],
+    entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, BaseEntity2, BaseEntity22],
+    tsConfigPath: BASE_DIR + '/tsconfig.test.json',
     dbName: `mikro_orm_test`,
     port,
     baseDir: BASE_DIR,

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -1,6 +1,6 @@
 import {
   AfterCreate, AfterDelete, AfterUpdate, BeforeCreate, BeforeDelete, BeforeUpdate,
-  Collection, Entity, OneToMany, Property, ManyToOne, PrimaryKey,
+  Collection, Entity, OneToMany, Property, ManyToOne,
 } from '../../lib';
 
 import { Book2 } from './Book2';
@@ -11,9 +11,6 @@ export class Author2 extends BaseEntity2 {
 
   static beforeDestroyCalled = 0;
   static afterDestroyCalled = 0;
-
-  @PrimaryKey()
-  id: number;
 
   @Property()
   createdAt = new Date();

--- a/tests/entities-sql/BaseEntity22.ts
+++ b/tests/entities-sql/BaseEntity22.ts
@@ -1,13 +1,10 @@
-import { Collection, IEntity, PrimaryKey } from '../../lib';
+import { Collection, IEntity } from '../../lib';
 import { MetadataStorage } from '../../lib/metadata/MetadataStorage';
 import { ReferenceType } from '../../lib/decorators/Entity';
 
-export abstract class BaseEntity2 {
+export abstract class BaseEntity22 {
 
-  @PrimaryKey()
-  id: number;
-
-  protected constructor() {
+  constructor() {
     const meta = MetadataStorage.getMetadata(this.constructor.name);
     const props = meta.properties;
 
@@ -20,4 +17,4 @@ export abstract class BaseEntity2 {
 
 }
 
-export interface BaseEntity2 extends IEntity<number> { }
+export interface BaseEntity22 extends IEntity<number> { }

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -1,4 +1,4 @@
-import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '../../lib';
+import { Collection, Entity, ManyToMany, ManyToOne, Property } from '../../lib';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
@@ -6,9 +6,6 @@ import { BaseEntity2 } from './BaseEntity2';
 
 @Entity()
 export class Book2 extends BaseEntity2 {
-
-  @PrimaryKey()
-  id: number;
 
   @Property()
   title: string;

--- a/tests/entities-sql/BookTag2.ts
+++ b/tests/entities-sql/BookTag2.ts
@@ -1,12 +1,9 @@
-import { Collection, Entity, ManyToMany, PrimaryKey, Property } from '../../lib';
+import { Collection, Entity, ManyToMany, Property } from '../../lib';
 import { Book2 } from './Book2';
 import { BaseEntity2 } from './BaseEntity2';
 
 @Entity()
 export class BookTag2 extends BaseEntity2 {
-
-  @PrimaryKey()
-  id: number;
 
   @Property()
   name: string;

--- a/tests/entities-sql/FooBar2.ts
+++ b/tests/entities-sql/FooBar2.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryKey, Property } from '../../lib';
+import { BaseEntity22 } from './BaseEntity22';
+
+@Entity()
+export class FooBar2 extends BaseEntity22 {
+
+  @PrimaryKey()
+  id: number;
+
+  @Property()
+  name: string;
+
+}

--- a/tests/entities-sql/FooBaz2.ts
+++ b/tests/entities-sql/FooBaz2.ts
@@ -1,0 +1,14 @@
+import { Entity, IEntity, PrimaryKey, Property } from '../../lib';
+
+@Entity()
+export class FooBaz2 {
+
+  @PrimaryKey()
+  id: number;
+
+  @Property()
+  name: string;
+
+}
+
+export interface FooBaz2 extends IEntity<number> { }

--- a/tests/entities-sql/Publisher2.ts
+++ b/tests/entities-sql/Publisher2.ts
@@ -1,13 +1,10 @@
-import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property } from '../../lib';
+import { Collection, Entity, ManyToMany, OneToMany, Property } from '../../lib';
 import { Book2 } from './Book2';
 import { Test2 } from './Test2';
 import { BaseEntity2 } from './BaseEntity2';
 
 @Entity()
 export class Publisher2 extends BaseEntity2 {
-
-  @PrimaryKey()
-  id: number;
 
   @Property()
   name: string;

--- a/tests/entities-sql/Test2.ts
+++ b/tests/entities-sql/Test2.ts
@@ -1,8 +1,7 @@
-import { Entity, PrimaryKey, Property } from '../../lib';
-import { BaseEntity2 } from './BaseEntity2';
+import { Entity, IEntity, PrimaryKey, Property } from '../../lib';
 
 @Entity()
-export class Test2 extends BaseEntity2 {
+export class Test2 {
 
   @PrimaryKey()
   id: number;
@@ -18,3 +17,5 @@ export class Test2 extends BaseEntity2 {
   }
 
 }
+
+export interface Test2 extends IEntity<number> { }

--- a/tests/tsconfig.test.json
+++ b/tests/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "experimentalDecorators": true
+  },
+  "include": [
+    "entities",
+    "entities-sql",
+    "repositories"
+  ]
+}


### PR DESCRIPTION
This adds new possibility to initialize ORM with array of entities instead of providing paths. Doing this, users can define entities like this:

```typescript
await MikroORM.init({
  entities: glob.sync('./src/entities/**/*.js').map(require),
  dbName: `db-name`,
});
```

Also make `entitiesDirsTs` optional by using `tsconfig.json` instead. 