### PR TITLE
feat(query-builder): add support for custom query expressions

### DIFF
--- a/lib/EntityManager.ts
+++ b/lib/EntityManager.ts
@@ -45,7 +45,7 @@ export class EntityManager {
 
   createQueryBuilder(entityName: EntityName<IEntity>): QueryBuilder {
     entityName = Utils.className(entityName);
-    return new QueryBuilder(entityName, this.metadata, this.getConnection(), this.driver.getPlatform());
+    return new QueryBuilder(entityName, this.metadata, this.driver);
   }
 
   async find<T extends IEntityType<T>>(entityName: EntityName<T>, where?: FilterQuery<T>, options?: FindOptions): Promise<T[]>;

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -1,4 +1,4 @@
-import { EntityData, EntityProperty, IEntity, IPrimaryKey } from '../decorators';
+import { EntityData, EntityMetadata, EntityProperty, IEntity, IEntityType, IPrimaryKey } from '../decorators';
 import { Connection, QueryResult } from '../connections';
 import { QueryOrder } from '../query';
 import { Platform } from '../platforms';
@@ -26,6 +26,8 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   count<T extends IEntity>(entityName: string, where: FilterQuery<T>): Promise<number>;
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
+
+  mapResult<T extends IEntityType<T>>(result: T, meta: EntityMetadata): T;
 
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -24,7 +24,7 @@ export class Utils {
   }
 
   static flatten<T>(arrays: T[][]): T[] {
-    return [].concat.apply([], arrays as any);
+    return [].concat(...arrays as any[]);
   }
 
   static merge(target: any, ...sources: any[]): any {

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -32,6 +32,18 @@ describe('QueryBuilder', () => {
     expect(qb.getParams()).toEqual([false]);
   });
 
+  test('select with custom expression', async () => {
+    const qb1 = orm.em.createQueryBuilder(Book2);
+    qb1.select('*').where({ 'JSON_CONTAINS(`e0`.`meta`, ?)': [{ foo: 'bar' }, true] });
+    expect(qb1.getQuery()).toEqual('SELECT `e0`.* FROM `book2` AS `e0` WHERE JSON_CONTAINS(`e0`.`meta`, ?) = ?');
+    expect(qb1.getParams()).toEqual(['{"foo":"bar"}', true]);
+
+    const qb2 = orm.em.createQueryBuilder(Book2);
+    qb2.select('*').where({ 'JSON_CONTAINS(`e0`.`meta`, ?)': [{ foo: 'baz' }, false] });
+    expect(qb2.getQuery()).toEqual('SELECT `e0`.* FROM `book2` AS `e0` WHERE JSON_CONTAINS(`e0`.`meta`, ?) = ?');
+    expect(qb2.getParams()).toEqual(['{"foo":"baz"}', false]);
+  });
+
   test('select by regexp', async () => {
     let qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*').where({ name: /test/ });

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -26,7 +26,7 @@ DROP TABLE IF EXISTS `book2`;
 
 CREATE TABLE `book2` (
   `uuid_pk` varchar(36) NOT NULL,
-  `created_at` datetime(3) DEFAULT CURRENT_TIMESTAMP(3),
+  `created_at` datetime(3) DEFAULT NOW(3),
   `title` varchar(255) DEFAULT NULL,
   `perex` text DEFAULT NULL,
   `price` float DEFAULT NULL,


### PR DESCRIPTION
Now it is possible to use custom expressions in where conditions:

`const book = await orm.em.findOne(Book, { 'JSON_CONTAINS(meta, ?)': [{ items: 1 }, true] });`

which will result in following query:

`SELECT `e0`.* FROM `book` AS `e0` WHERE JSON_CONTAINS(meta, ?) = ?` with params `['{"items":1}', true]`