### PR TITLE
feat(core): automatically fix wrongly assigned associations

### DIFF
--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -1,6 +1,6 @@
 import { EntityData, EntityMetadata, EntityProperty, IEntity, IEntityType, IPrimaryKey } from '../decorators';
 import { Connection, QueryResult } from '../connections';
-import { QueryOrder } from '../query';
+import { QueryOrderMap } from '../query';
 import { Platform } from '../platforms';
 import { LockMode } from '../unit-of-work';
 

--- a/lib/entity/ArrayCollection.ts
+++ b/lib/entity/ArrayCollection.ts
@@ -1,4 +1,4 @@
-import { EntityProperty, IEntity, IEntityType, IPrimaryKey } from '../decorators';
+import { EntityProperty, IEntityType, IPrimaryKey } from '../decorators';
 import { MetadataStorage } from '../metadata';
 
 export class ArrayCollection<T extends IEntityType<T>> {
@@ -76,9 +76,9 @@ export class ArrayCollection<T extends IEntityType<T>> {
   contains(item: T): boolean {
     return !!this.items.find(i => {
       const objectIdentity = i === item;
-      const primaryKeyIdentity = i.__primaryKey && item.__primaryKey && i.__serializedPrimaryKey === item.__serializedPrimaryKey;
+      const primaryKeyIdentity = !!i.__primaryKey && !!item.__primaryKey && i.__serializedPrimaryKey === item.__serializedPrimaryKey;
 
-      return !!(objectIdentity || primaryKeyIdentity);
+      return objectIdentity || primaryKeyIdentity;
     });
   }
 

--- a/lib/entity/Collection.ts
+++ b/lib/entity/Collection.ts
@@ -1,4 +1,4 @@
-import { FilterQuery, QueryOrder, QueryOrderMap } from '..';
+import { FilterQuery, QueryOrder, QueryOrderMap, Utils } from '..';
 import { IEntityType } from '../decorators';
 import { ArrayCollection } from './ArrayCollection';
 import { ReferenceType } from './enums';
@@ -32,7 +32,7 @@ export class Collection<T extends IEntityType<T>> extends ArrayCollection<T> {
       this.initialized = true;
     }
 
-    super.set(items);
+    super.set(items.map(item => Utils.isEntity(item) ? item : this.owner.__em.getReference(this.property.type, item)));
     this.dirty = !initialize;
 
     for (const item of items) {


### PR DESCRIPTION
When you use `Object.assign(entity, { ... })` instead of `entity.assign({ ... })` you could put your entity
into invalid state where there will be PK instead of entity reference. With this change all managed entities
will be validated before flushing and this case will be automatically handled, converting the PK to entity
when persisting it.

This is especially handy when you migrate existing project where you used `Object.assign(entity, { ... })`
to update entities (like in TypeORM) as this kind of error could be hard to find because they were failing
silently.