### PR TITLE
feat(core): use knex as query runner + enable connection pooling

### DIFF
--- a/lib/connections/AbstractSqlConnection.ts
+++ b/lib/connections/AbstractSqlConnection.ts
@@ -1,0 +1,100 @@
+import * as Knex from 'knex';
+import { Config, QueryBuilder, Raw, Transaction } from 'knex';
+import { readFile } from 'fs-extra';
+
+import { Connection, QueryResult } from './Connection';
+import { Utils } from '../utils';
+import { EntityData, IEntity } from '../decorators';
+
+export abstract class AbstractSqlConnection extends Connection {
+
+  protected client: Knex;
+
+  getKnex(): Knex {
+    return this.client;
+  }
+
+  async close(force?: boolean): Promise<void> {
+    await this.client.destroy();
+  }
+
+  async isConnected(): Promise<boolean> {
+    try {
+      await this.client.raw('select 1');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async transactional(cb: (trx: Transaction) => Promise<any>, ctx?: Transaction): Promise<any> {
+    await (ctx || this.client).transaction(async trx => {
+      try {
+        const ret = await cb(trx);
+        await trx.commit();
+
+        return ret;
+      } catch (e) {
+        await trx.rollback(e);
+        throw e;
+      }
+    });
+  }
+
+  async execute<T = QueryResult | EntityData<IEntity> | EntityData<IEntity>[]>(queryOrKnex: string | QueryBuilder | Raw, params: any[] = [], method: 'all' | 'get' | 'run' = 'all'): Promise<T> {
+    if (Utils.isObject<QueryBuilder | Raw>(queryOrKnex)) {
+      return await this.executeKnex(queryOrKnex, method);
+    }
+
+    const res = await this.executeQuery<any>(queryOrKnex, params, () => this.client.raw(queryOrKnex, params));
+    return this.transformRawResult<T>(res, method);
+  }
+
+  async loadFile(path: string): Promise<void> {
+    const buf = await readFile(path);
+    await this.client.raw(buf.toString());
+  }
+
+  protected createKnexClient(type: string): Knex {
+    return Knex(this.getKnexOptions(type))
+      .on('query', data => {
+        if (!data.__knexQueryUid) {
+          this.logQuery(data.sql.toLowerCase().replace(/;$/, ''));
+        }
+      });
+  }
+
+  protected getKnexOptions(type: string): Config {
+    return {
+      client: type,
+      connection: this.getConnectionOptions(),
+      pool: this.config.get('pool'),
+    };
+  }
+
+  protected async executeKnex(qb: QueryBuilder | Raw, method: 'all' | 'get' | 'run'): Promise<QueryResult | any | any[]> {
+    const q = qb.toSQL();
+    const query = q.toNative ? q.toNative() : q;
+    const res = await this.executeQuery(query.sql, query.bindings, () => qb);
+
+    return this.transformKnexResult(res, method);
+  }
+
+  protected transformKnexResult(res: any, method: 'all' | 'get' | 'run'): QueryResult | any | any[] {
+    if (method === 'all') {
+      return res;
+    }
+
+    if (method === 'get') {
+      return res[0];
+    }
+
+    const affectedRows = typeof res === 'number' ? res : 0;
+    const insertId = typeof res[0] === 'number' ? res[0] : 0;
+
+    return { insertId, affectedRows, row: res[0] };
+  }
+
+  protected abstract transformRawResult<T>(res: any, method: 'all' | 'get' | 'run'): T;
+
+}

--- a/lib/connections/MySqlConnection.ts
+++ b/lib/connections/MySqlConnection.ts
@@ -1,56 +1,18 @@
-import { Connection as MySql2Connection, ConnectionOptions, createConnection } from 'mysql2/promise';
-import { readFile } from 'fs-extra';
-import { Connection, QueryResult } from './Connection';
+import { MySqlConnectionConfig } from 'knex';
+import { AbstractSqlConnection } from './AbstractSqlConnection';
 
-export class MySqlConnection extends Connection {
-
-  protected client: MySql2Connection;
+export class MySqlConnection extends AbstractSqlConnection {
 
   async connect(): Promise<void> {
-    this.client = await createConnection(this.getConnectionOptions());
-  }
-
-  async close(force?: boolean): Promise<void> {
-    await this.client.end({ force });
-  }
-
-  async isConnected(): Promise<boolean> {
-    try {
-      await this.client.query('SELECT 1');
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  async beginTransaction(): Promise<void> {
-    await this.query('START TRANSACTION');
-  }
-
-  async commit(): Promise<void> {
-    await this.query('COMMIT');
-  }
-
-  async rollback(): Promise<void> {
-    await this.query('ROLLBACK');
+    this.client = this.createKnexClient('mysql2');
   }
 
   getDefaultClientUrl(): string {
     return 'mysql://root@127.0.0.1:3306';
   }
 
-  async execute(query: string, params: any[] = [], method: 'all' | 'get' | 'run' = 'all'): Promise<QueryResult | any | any[]> {
-    const res = await this.executeQuery(query, params, () => this.client.execute(query, params));
-
-    if (method === 'get') {
-      return (res as QueryResult[][])[0][0];
-    }
-
-    return res[0];
-  }
-
-  getConnectionOptions(): ConnectionOptions {
-    const ret: ConnectionOptions = super.getConnectionOptions();
+  getConnectionOptions(): MySqlConnectionConfig {
+    const ret: MySqlConnectionConfig = super.getConnectionOptions();
 
     if (this.config.get('multipleStatements')) {
       ret.multipleStatements = this.config.get('multipleStatements');
@@ -59,14 +21,19 @@ export class MySqlConnection extends Connection {
     return ret;
   }
 
-  async loadFile(path: string): Promise<void> {
-    await this.client.query((await readFile(path)).toString());
-  }
+  protected transformRawResult<T>(res: any, method: 'all' | 'get' | 'run'): T {
+    if (method === 'run' && res[0].constructor.name === 'ResultSetHeader') {
+      return {
+        insertId: res[0].insertId,
+        affectedRows: res[0].affectedRows,
+      } as unknown as T;
+    }
 
-  private async query(sql: string): Promise<void> {
-    const now = Date.now();
-    await this.client.query(sql);
-    this.logQuery(sql, Date.now() - now);
+    if (method === 'get') {
+      return res[0][0];
+    }
+
+    return res[0];
   }
 
 }

--- a/lib/connections/PostgreSqlConnection.ts
+++ b/lib/connections/PostgreSqlConnection.ts
@@ -1,69 +1,29 @@
-import { Client } from 'pg';
-import { readFile } from 'fs-extra';
-import { Connection, QueryResult } from './Connection';
-import { EntityData, IEntity } from '../decorators';
+import { AbstractSqlConnection } from './AbstractSqlConnection';
 
-export class PostgreSqlConnection extends Connection {
-
-  protected client: Client;
+export class PostgreSqlConnection extends AbstractSqlConnection {
 
   async connect(): Promise<void> {
-    this.client = new Client(this.getConnectionOptions());
-    await this.client.connect();
-  }
-
-  async close(force?: boolean): Promise<void> {
-    await this.client.end();
-  }
-
-  async isConnected(): Promise<boolean> {
-    try {
-      await this.client.query('SELECT 1');
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  async beginTransaction(savepoint?: string): Promise<void> {
-    await this.execute(savepoint ? `SAVEPOINT ${savepoint}` : 'START TRANSACTION', [], 'run');
-  }
-
-  async commit(savepoint?: string): Promise<void> {
-    await this.execute(savepoint ? `RELEASE SAVEPOINT ${savepoint}` : 'COMMIT', [], 'run');
-  }
-
-  async rollback(savepoint?: string): Promise<void> {
-    await this.execute(savepoint ? `ROLLBACK TO SAVEPOINT ${savepoint}` : 'ROLLBACK', [], 'run');
+    this.client = this.createKnexClient('pg');
   }
 
   getDefaultClientUrl(): string {
     return 'postgre://postgres@127.0.0.1:5432';
   }
 
-  async execute(query: string, params: any[] = [], method: 'all' | 'get' | 'run' = 'all'): Promise<QueryResult | any | any[]> {
-    const res = await this.executeQuery(query, params, () => this.client.query(query, params));
-    return this.transformResult(res, method);
-  }
-
-  async loadFile(path: string): Promise<void> {
-    await this.client.query((await readFile(path)).toString());
-  }
-
-  private transformResult(res: any, method: 'all' | 'get' | 'run'): QueryResult | EntityData<IEntity> | EntityData<IEntity>[] {
+  protected transformRawResult<T>(res: any, method: 'all' | 'get' | 'run'): T {
     if (method === 'get') {
       return res.rows[0];
     }
 
-    if (method === 'run') {
-      return {
-        affectedRows: res.rowCount || 0,
-        insertId: res.rows[0] ? res.rows[0].id : 0,
-        row: res.rows[0],
-      };
+    if (method === 'all') {
+      return res.rows;
     }
 
-    return res.rows;
+    return {
+      affectedRows: res.rowCount,
+      insertId: res.rows[0] ? res.rows[0].id : 0,
+      row: res.rows[0],
+    } as unknown as T;
   }
 
 }

--- a/lib/connections/SqliteConnection.ts
+++ b/lib/connections/SqliteConnection.ts
@@ -1,37 +1,14 @@
-import * as sqlite from 'sqlite';
-import { Database } from 'sqlite';
 import { readFile } from 'fs-extra';
+import { Config } from 'knex';
+const Bluebird = require('bluebird');
 
-import { Connection, QueryResult } from './Connection';
-import { EntityData, IEntity } from '../decorators';
+import { AbstractSqlConnection } from './AbstractSqlConnection';
 
-export class SqliteConnection extends Connection {
-
-  protected client: SqliteDatabase;
+export class SqliteConnection extends AbstractSqlConnection {
 
   async connect(): Promise<void> {
-    this.client = await sqlite.open(this.config.get('dbName')) as SqliteDatabase;
-    await this.client.exec('PRAGMA foreign_keys = ON');
-  }
-
-  async close(force?: boolean): Promise<void> {
-    await this.client.close();
-  }
-
-  async isConnected(): Promise<boolean> {
-    return this.client['driver']['open'];
-  }
-
-  async beginTransaction(savepoint?: string): Promise<void> {
-    await this.execute(savepoint ? `SAVEPOINT ${savepoint}` : 'BEGIN', [], 'run');
-  }
-
-  async commit(savepoint?: string): Promise<void> {
-    await this.execute(savepoint ? `RELEASE SAVEPOINT ${savepoint}` : 'COMMIT', [], 'run');
-  }
-
-  async rollback(savepoint?: string): Promise<void> {
-    await this.execute(savepoint ? `ROLLBACK TO SAVEPOINT ${savepoint}` : 'ROLLBACK', [], 'run');
+    this.client = this.createKnexClient(this.getPatchedDialect());
+    await this.client.raw('pragma foreign_keys = on');
   }
 
   getDefaultClientUrl(): string {
@@ -42,45 +19,91 @@ export class SqliteConnection extends Connection {
     return '';
   }
 
-  async execute(query: string, params: any[] = [], method: 'all' | 'get' | 'run' = 'all'): Promise<QueryResult | any | any[]> {
-    params = params.map(p => {
-      if (p instanceof Date) {
-        p = p.toISOString();
-      }
-
-      if (typeof p === 'boolean') {
-        p = +p;
-      }
-
-      return p;
-    });
-
-    const res = await this.executeQuery(query, params, async () => {
-      const statement = await this.client.prepare(query);
-      const result = await statement[method](...params);
-      await statement.finalize();
-
-      return result;
-    });
-
-    return this.transformResult(res, method);
-  }
-
   async loadFile(path: string): Promise<void> {
-    await this.client.exec((await readFile(path)).toString());
+    const conn = await this.client.client.acquireConnection();
+    await conn.exec((await readFile(path)).toString());
+    await this.client.client.releaseConnection(conn);
   }
 
-  private transformResult(res: any, method: 'all' | 'get' | 'run'): QueryResult | EntityData<IEntity> | EntityData<IEntity>[] {
-    if (method === 'run') {
-      return {
-        affectedRows: res.changes,
-        insertId: res.lastID,
-      };
+  protected getKnexOptions(type: string): Config {
+    return {
+      client: type,
+      connection: {
+        filename: this.config.get('dbName'),
+      },
+      useNullAsDefault: true,
+    };
+  }
+
+  protected transformRawResult<T>(res: any, method: 'all' | 'get' | 'run'): T {
+    if (method === 'get') {
+      return res[0];
     }
 
-    return res;
+    if (method === 'all') {
+      return res;
+    }
+
+    return {
+      insertId: res.lastID,
+      affectedRows: res.changes,
+    } as unknown as T;
+  }
+
+  /**
+   * monkey patch knex' sqlite dialect so it returns inserted id when doing raw insert query
+   */
+  private getPatchedDialect() {
+    const dialect = require('knex/lib/dialects/sqlite3/index.js');
+
+    const processResponse = dialect.prototype.processResponse;
+    dialect.prototype.processResponse = (obj: any, runner: any) => {
+      if (obj.method === 'raw' && obj.sql.trim().match('^insert into|update|delete')) {
+        return obj.context;
+      }
+
+      return processResponse(obj, runner);
+    };
+
+    dialect.prototype._query = (connection: any, obj: any) => {
+      const callMethod = this.getCallMethod(obj);
+
+      return new Bluebird((resolve: any, reject: any) => {
+        /* istanbul ignore if */
+        if (!connection || !connection[callMethod]) {
+          return reject(new Error(`Error calling ${callMethod} on connection.`));
+        }
+
+        connection[callMethod](obj.sql, obj.bindings, function (this: any, err: any, response: any) {
+          if (err) {
+            return reject(err);
+          }
+
+          obj.response = response;
+          obj.context = this;
+
+          return resolve(obj);
+        });
+      });
+    };
+
+    return dialect;
+  }
+
+  private getCallMethod(obj: any): string {
+    if (obj.method === 'raw' && obj.sql.trim().match('^insert into|update|delete')) {
+      return 'run';
+    }
+
+    switch (obj.method) {
+      case 'insert':
+      case 'update':
+      case 'counter':
+      case 'del':
+        return 'run';
+      default:
+        return 'all';
+    }
   }
 
 }
-
-export type SqliteDatabase = Database & { driver: { open: boolean } };

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -65,9 +65,10 @@ export interface EntityProperty<T extends IEntityType<T> = any> {
   length?: any;
   reference: ReferenceType;
   fieldName: string;
-  default?: string;
+  default?: any;
   unique?: boolean;
   nullable?: boolean;
+  unsigned: boolean;
   persist?: boolean;
   hidden?: boolean;
   version?: boolean;

--- a/lib/decorators/Property.ts
+++ b/lib/decorators/Property.ts
@@ -21,6 +21,7 @@ export type PropertyOptions = {
   default?: any;
   unique?: boolean;
   nullable?: boolean;
+  unsigned?: boolean;
   persist?: boolean;
   hidden?: boolean;
   version?: boolean;

--- a/lib/drivers/AbstractSqlDriver.ts
+++ b/lib/drivers/AbstractSqlDriver.ts
@@ -1,16 +1,18 @@
+import { Transaction } from 'knex';
 import { EntityData, IEntityType, IPrimaryKey } from '../decorators';
 import { DatabaseDriver } from './DatabaseDriver';
-import { Connection, QueryResult } from '../connections';
+import { QueryResult } from '../connections';
+import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 import { ReferenceType } from '../entity';
 import { FilterQuery } from './IDatabaseDriver';
 import { QueryBuilder, QueryOrderMap } from '../query';
 import { Utils } from '../utils';
 import { LockMode } from '../unit-of-work';
 
-export abstract class AbstractSqlDriver<C extends Connection> extends DatabaseDriver<C> {
+export abstract class AbstractSqlDriver<C extends AbstractSqlConnection = AbstractSqlConnection> extends DatabaseDriver<C> {
 
-  async find<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T>, populate: string[] = [], orderBy: QueryOrderMap = {}, limit?: number, offset?: number): Promise<T[]> {
-    const qb = this.createQueryBuilder(entityName);
+  async find<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T>, populate: string[] = [], orderBy: QueryOrderMap = {}, limit?: number, offset?: number, ctx?: Transaction): Promise<T[]> {
+    const qb = this.createQueryBuilder(entityName, ctx);
     qb.select('*').populate(populate).where(where).orderBy(orderBy);
 
     if (limit !== undefined) {
@@ -20,7 +22,7 @@ export abstract class AbstractSqlDriver<C extends Connection> extends DatabaseDr
     return qb.execute('all');
   }
 
-  async findOne<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T> | string, populate: string[] = [], orderBy: QueryOrderMap = {}, fields?: string[], lockMode?: LockMode): Promise<T | null> {
+  async findOne<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T> | string, populate: string[] = [], orderBy: QueryOrderMap = {}, fields?: string[], lockMode?: LockMode, ctx?: Transaction): Promise<T | null> {
     const pk = this.metadata[entityName].primaryKey;
 
     if (Utils.isPrimaryKey(where)) {
@@ -31,7 +33,7 @@ export abstract class AbstractSqlDriver<C extends Connection> extends DatabaseDr
       fields.unshift(pk);
     }
 
-    return this.createQueryBuilder(entityName)
+    return this.createQueryBuilder(entityName, ctx)
       .select(fields || '*')
       .populate(populate)
       .where(where)
@@ -41,61 +43,57 @@ export abstract class AbstractSqlDriver<C extends Connection> extends DatabaseDr
       .execute('get');
   }
 
-  async count(entityName: string, where: any): Promise<number> {
-    const qb = this.createQueryBuilder(entityName);
+  async count(entityName: string, where: any, ctx?: Transaction): Promise<number> {
+    const qb = this.createQueryBuilder(entityName, ctx);
     const pk = this.metadata[entityName].primaryKey;
     const res = await qb.count(pk, true).where(where).execute('get', false);
 
     return +res.count;
   }
 
-  async nativeInsert<T extends IEntityType<T>>(entityName: string, data: EntityData<T>): Promise<QueryResult> {
+  async nativeInsert<T extends IEntityType<T>>(entityName: string, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult> {
     const collections = this.extractManyToMany(entityName, data);
-    const pk = this.getPrimaryKeyField(entityName) as keyof T;
-
-    if (Object.keys(data).length === 0) {
-      data[pk] = null as T[keyof T];
-    }
-
-    const qb = this.createQueryBuilder(entityName);
+    const pk = this.getPrimaryKeyField(entityName);
+    const qb = this.createQueryBuilder(entityName, ctx);
     const res = await qb.insert(data).execute('run', false);
-    res.insertId = res.insertId || data[pk];
-    await this.processManyToMany(entityName, res.insertId, collections);
+    res.row = res.row || {};
+    res.insertId = res.insertId || res.row[pk] || data[pk];
+    await this.processManyToMany(entityName, res.insertId, collections, ctx);
 
     return res;
   }
 
-  async nativeUpdate<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T>, data: EntityData<T>): Promise<QueryResult> {
-    const pk = this.metadata[entityName] ? this.metadata[entityName].primaryKey : this.config.getNamingStrategy().referenceColumnName();
+  async nativeUpdate<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T>, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult> {
+    const pk = this.getPrimaryKeyField(entityName);
 
     if (Utils.isPrimaryKey(where)) {
       where = { [pk]: where };
     }
 
     const collections = this.extractManyToMany(entityName, data);
-    let res: QueryResult = { affectedRows: 0, insertId: 0 };
+    let res: QueryResult = { affectedRows: 0, insertId: 0, row: {} };
 
     if (Object.keys(data).length) {
-      const qb = this.createQueryBuilder(entityName);
+      const qb = this.createQueryBuilder(entityName, ctx);
       res = await qb.update(data).where(where).execute('run', false);
     }
 
-    await this.processManyToMany(entityName, Utils.extractPK(data[pk] || where, this.metadata[entityName])!, collections);
+    await this.processManyToMany(entityName, Utils.extractPK(data[pk] || where, this.metadata[entityName])!, collections, ctx);
 
     return res;
   }
 
-  async nativeDelete<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T> | string | any): Promise<QueryResult> {
+  async nativeDelete<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T> | string | any, ctx?: Transaction): Promise<QueryResult> {
     if (Utils.isPrimaryKey(where)) {
-      const pk = this.metadata[entityName] ? this.metadata[entityName].primaryKey : this.config.getNamingStrategy().referenceColumnName();
+      const pk = this.getPrimaryKeyField(entityName);
       where = { [pk]: where };
     }
 
-    return this.createQueryBuilder(entityName).delete(where).execute('run', false);
+    return this.createQueryBuilder(entityName, ctx).delete(where).execute('run', false);
   }
 
-  protected createQueryBuilder(entityName: string): QueryBuilder {
-    return new QueryBuilder(entityName, this.metadata, this);
+  protected createQueryBuilder(entityName: string, ctx?: Transaction): QueryBuilder {
+    return new QueryBuilder(entityName, this.metadata, this, ctx);
   }
 
   protected extractManyToMany<T extends IEntityType<T>>(entityName: string, data: EntityData<T>): EntityData<T> {
@@ -118,7 +116,7 @@ export abstract class AbstractSqlDriver<C extends Connection> extends DatabaseDr
     return ret;
   }
 
-  protected async processManyToMany<T extends IEntityType<T>>(entityName: string, pk: IPrimaryKey, collections: EntityData<T>) {
+  protected async processManyToMany<T extends IEntityType<T>>(entityName: string, pk: IPrimaryKey, collections: EntityData<T>, ctx?: Transaction) {
     if (!this.metadata[entityName]) {
       return;
     }
@@ -130,11 +128,11 @@ export abstract class AbstractSqlDriver<C extends Connection> extends DatabaseDr
       const prop = props[k];
       const fk1 = prop.joinColumn;
       const fk2 = prop.inverseJoinColumn;
-      const qb1 = this.createQueryBuilder(prop.pivotTable);
+      const qb1 = this.createQueryBuilder(prop.pivotTable, ctx);
       await qb1.delete({ [fk1]: pk }).execute('run', false);
 
       for (const item of collections[k]) {
-        const qb2 = this.createQueryBuilder(prop.pivotTable);
+        const qb2 = this.createQueryBuilder(prop.pivotTable, ctx);
         await qb2.insert({ [fk1]: pk, [fk2]: item }).execute('run', false);
       }
     }

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -1,5 +1,5 @@
 import { EntityData, EntityMetadata, EntityProperty, IEntity, IEntityType, IPrimaryKey } from '../decorators';
-import { Connection, QueryResult } from '../connections';
+import { Connection, QueryResult, Transaction } from '../connections';
 import { QueryOrderMap } from '../query';
 import { Platform } from '../platforms';
 import { LockMode } from '../unit-of-work';
@@ -11,20 +11,20 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * Finds selection of entities
    */
-  find<T extends IEntity>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: QueryOrderMap, limit?: number, offset?: number): Promise<T[]>;
+  find<T extends IEntity>(entityName: string, where: FilterQuery<T>, populate?: string[], orderBy?: QueryOrderMap, limit?: number, offset?: number, ctx?: Transaction): Promise<T[]>;
 
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], lockMode?: LockMode): Promise<T | null>;
+  findOne<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, populate?: string[], orderBy?: QueryOrderMap, fields?: string[], lockMode?: LockMode, ctx?: Transaction): Promise<T | null>;
 
-  nativeInsert<T extends IEntity>(entityName: string, data: EntityData<T>): Promise<QueryResult>;
+  nativeInsert<T extends IEntity>(entityName: string, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
-  nativeUpdate<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, data: EntityData<T>): Promise<QueryResult>;
+  nativeUpdate<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, data: EntityData<T>, ctx?: Transaction): Promise<QueryResult>;
 
-  nativeDelete<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey): Promise<QueryResult>;
+  nativeDelete<T extends IEntity>(entityName: string, where: FilterQuery<T> | IPrimaryKey, ctx?: Transaction): Promise<QueryResult>;
 
-  count<T extends IEntity>(entityName: string, where: FilterQuery<T>): Promise<number>;
+  count<T extends IEntity>(entityName: string, where: FilterQuery<T>, ctx?: Transaction): Promise<number>;
 
   aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 
@@ -33,29 +33,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * When driver uses pivot tables for M:N, this method will load identifiers for given collections from them
    */
-  loadFromPivotTable<T extends IEntity>(prop: EntityProperty, owners: IPrimaryKey[]): Promise<Record<string, T[]>>;
-
-  /**
-   * Begins a transaction (if supported)
-   */
-  beginTransaction(): Promise<void>;
-
-  /**
-   * Commits statements in a transaction
-   */
-  commit(): Promise<void>;
-
-  /**
-   * Rollback changes in a transaction
-   */
-  rollback(): Promise<void>;
-
-  /**
-   * Runs callback inside transaction
-   */
-  transactional(cb: () => Promise<any>): Promise<any>;
-
-  isInTransaction(): boolean;
+  loadFromPivotTable<T extends IEntity>(prop: EntityProperty, owners: IPrimaryKey[], ctx?: Transaction): Promise<Record<string, T[]>>;
 
   getPlatform(): Platform;
 

--- a/lib/drivers/PostgreSqlDriver.ts
+++ b/lib/drivers/PostgreSqlDriver.ts
@@ -1,33 +1,10 @@
 import { PostgreSqlConnection } from '../connections/PostgreSqlConnection';
 import { AbstractSqlDriver } from './AbstractSqlDriver';
-import { EntityData, IEntityType } from '../decorators';
-import { QueryType } from '../query';
 import { PostgreSqlPlatform } from '../platforms/PostgreSqlPlatform';
-import { QueryResult } from '../connections';
 
 export class PostgreSqlDriver extends AbstractSqlDriver<PostgreSqlConnection> {
 
   protected readonly connection = new PostgreSqlConnection(this.config);
   protected readonly platform = new PostgreSqlPlatform();
-
-  async nativeInsert<T extends IEntityType<T>>(entityName: string, data: EntityData<T>): Promise<QueryResult> {
-    const collections = this.extractManyToMany(entityName, data);
-    const qb = this.createQueryBuilder(entityName).insert(data);
-    const params = qb.getParams();
-    let sql = qb.getQuery();
-
-    if (qb.type === QueryType.INSERT && Object.keys(params).length === 0) {
-      const pk = this.getPrimaryKeyField(entityName);
-      const prop = this.metadata[entityName].properties[pk];
-      sql = sql.replace('() VALUES ()', `("${prop.fieldName}") VALUES (DEFAULT)`);
-    }
-
-    const res = await this.connection.execute(sql, params, 'run');
-    const pk = this.getPrimaryKeyField(entityName);
-    res.insertId = res.insertId || data[pk];
-    await this.processManyToMany(entityName, res.insertId, collections);
-
-    return res;
-  }
 
 }

--- a/lib/entity/EntityLoader.ts
+++ b/lib/entity/EntityLoader.ts
@@ -115,7 +115,7 @@ export class EntityLoader {
   }
 
   private async findChildrenFromPivotTable<T extends IEntityType<T>>(filtered: T[], prop: EntityProperty, field: keyof T): Promise<IEntity[]> {
-    const map = await this.driver.loadFromPivotTable(prop, filtered.map(e => e.__primaryKey));
+    const map = await this.driver.loadFromPivotTable(prop, filtered.map(e => e.__primaryKey), this.em.getTransactionContext());
     const children: IEntity[] = [];
 
     for (const entity of filtered) {

--- a/lib/entity/EntityValidator.ts
+++ b/lib/entity/EntityValidator.ts
@@ -98,7 +98,7 @@ export class EntityValidator {
   }
 
   private fixDateType(givenValue: string): Date | string {
-    const date = new Date(givenValue);
+    const date = new Date(parseFloat(givenValue) || givenValue);
     return date.toString() !== 'Invalid Date' ? date : givenValue;
   }
 

--- a/lib/metadata/MetadataDiscovery.ts
+++ b/lib/metadata/MetadataDiscovery.ts
@@ -227,7 +227,7 @@ export class MetadataDiscovery {
   private definePivotTableEntity(meta: EntityMetadata, prop: EntityProperty): EntityMetadata | undefined {
     if (prop.reference === ReferenceType.MANY_TO_MANY && prop.owner && prop.pivotTable) {
       const pk = this.namingStrategy.referenceColumnName();
-      const primaryProp = { name: pk, type: 'number', reference: ReferenceType.SCALAR, primary: true } as EntityProperty;
+      const primaryProp = { name: pk, type: 'number', reference: ReferenceType.SCALAR, primary: true, unsigned: true } as EntityProperty;
       this.initFieldName(primaryProp);
 
       return this.metadata[prop.pivotTable] = {
@@ -292,7 +292,7 @@ export class MetadataDiscovery {
     }
   }
 
-  private getDefaultVersionValue(prop: EntityProperty): string {
+  private getDefaultVersionValue(prop: EntityProperty): any {
     if (prop.default) {
       return prop.default;
     }
@@ -302,7 +302,7 @@ export class MetadataDiscovery {
       return this.platform.getCurrentTimestampSQL(prop.length);
     }
 
-    return '1';
+    return 1;
   }
 
 }

--- a/lib/platforms/MySqlPlatform.ts
+++ b/lib/platforms/MySqlPlatform.ts
@@ -5,8 +5,4 @@ export class MySqlPlatform extends Platform {
 
   protected schemaHelper = new MySqlSchemaHelper();
 
-  getReadLockSQL(): string {
-    return 'LOCK IN SHARE MODE';
-  }
-
 }

--- a/lib/platforms/Platform.ts
+++ b/lib/platforms/Platform.ts
@@ -14,16 +14,8 @@ export abstract class Platform {
     return true;
   }
 
-  supportsSavePoints(): boolean {
-    return false;
-  }
-
-  getNamingStrategy(): { new(): NamingStrategy} {
+  getNamingStrategy(): { new(): NamingStrategy } {
     return UnderscoreNamingStrategy;
-  }
-
-  getParameterPlaceholder(index?: number): string {
-    return '?';
   }
 
   usesReturningStatement(): boolean {
@@ -67,34 +59,7 @@ export abstract class Platform {
    * Returns the SQL specific for the platform to get the current timestamp
    */
   getCurrentTimestampSQL(length: number): string {
-    return 'CURRENT_TIMESTAMP' + (length ? `(${length})` : '');
-  }
-
-  /**
-   * Returns the FOR UPDATE expression.
-   *
-   */
-  getForUpdateSQL(): string {
-    return 'FOR UPDATE';
-  }
-
-  /**
-   * Returns the SQL snippet to append to any SELECT statement which locks rows in shared read lock.
-   *
-   * This defaults to the ANSI SQL "FOR UPDATE", which is an exclusive lock (Write). Some database
-   * vendors allow to lighten this constraint up to be a real read lock.
-   */
-  getReadLockSQL(): string {
-    return this.getForUpdateSQL();
-  }
-
-  /**
-   * Returns the SQL snippet to append to any SELECT statement which obtains an exclusive lock on the rows.
-   *
-   * The semantics of this lock mode should equal the SELECT .. FOR UPDATE of the ANSI SQL standard.
-   */
-  getWriteLockSQL(): string {
-    return this.getForUpdateSQL();
+    return 'current_timestamp' + (length ? `(${length})` : '');
   }
 
 }

--- a/lib/platforms/PostgreSqlPlatform.ts
+++ b/lib/platforms/PostgreSqlPlatform.ts
@@ -1,4 +1,3 @@
-import { NamingStrategy, UnderscoreNamingStrategy } from '../naming-strategy';
 import { Platform } from './Platform';
 import { PostgreSqlSchemaHelper } from '../schema/PostgreSqlSchemaHelper';
 
@@ -6,28 +5,12 @@ export class PostgreSqlPlatform extends Platform {
 
   protected schemaHelper = new PostgreSqlSchemaHelper();
 
-  supportsSavePoints(): boolean {
-    return true;
-  }
-
-  getNamingStrategy(): { new(): NamingStrategy} {
-    return UnderscoreNamingStrategy;
-  }
-
-  getParameterPlaceholder(index?: number): string {
-    return '$' + index;
-  }
-
   usesReturningStatement(): boolean {
     return true;
   }
 
   usesCascadeStatement(): boolean {
     return true;
-  }
-
-  getReadLockSQL(): string {
-    return 'FOR SHARE';
   }
 
 }

--- a/lib/platforms/SqlitePlatform.ts
+++ b/lib/platforms/SqlitePlatform.ts
@@ -5,20 +5,12 @@ export class SqlitePlatform extends Platform {
 
   protected schemaHelper = new SqliteSchemaHelper();
 
-  supportsSavePoints(): boolean {
-    return true;
-  }
-
   requiresNullableForAlteringColumn() {
     return true;
   }
 
   getCurrentTimestampSQL(length: number): string {
     return super.getCurrentTimestampSQL(0);
-  }
-
-  getForUpdateSQL(): string {
-    return '';
   }
 
 }

--- a/lib/query/QueryBuilder.ts
+++ b/lib/query/QueryBuilder.ts
@@ -1,11 +1,13 @@
+import { QueryBuilder as KnexQueryBuilder, Raw, Transaction } from 'knex';
 import { Utils, ValidationError } from '../utils';
 import { QueryBuilderHelper } from './QueryBuilderHelper';
 import { SmartQueryHelper } from './SmartQueryHelper';
 import { EntityMetadata, EntityProperty } from '../decorators';
 import { ReferenceType } from '../entity';
 import { QueryFlag, QueryOrderMap, QueryType } from './enums';
-import { IDatabaseDriver } from '../drivers';
 import { LockMode } from '../unit-of-work';
+import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
+import { IDatabaseDriver } from '../drivers';
 
 /**
  * SQL query builder
@@ -30,13 +32,15 @@ export class QueryBuilder {
   private _limit: number;
   private _offset: number;
   private lockMode?: LockMode;
-  private readonly connection = this.driver.getConnection();
+  private readonly connection = this.driver.getConnection() as AbstractSqlConnection;
   private readonly platform = this.driver.getPlatform();
-  private readonly helper = new QueryBuilderHelper(this.entityName, this.alias, this._aliasMap, this.metadata, this.platform);
+  private readonly knex = this.connection.getKnex();
+  private readonly helper = new QueryBuilderHelper(this.entityName, this.alias, this._aliasMap, this.metadata, this.knex, this.platform);
 
   constructor(private readonly entityName: string,
               private readonly metadata: Record<string, EntityMetadata>,
               private readonly driver: IDatabaseDriver,
+              private readonly context?: Transaction,
               readonly alias = `e0`) { }
 
   select(fields: string | string[], distinct = false): this {
@@ -66,17 +70,16 @@ export class QueryBuilder {
   }
 
   count(field?: string, distinct = false): this {
-    this.select(field || this.metadata[this.entityName].primaryKey);
-    this.flags.push(QueryFlag.COUNT);
+    this._fields = [field || this.metadata[this.entityName].primaryKey];
 
     if (distinct) {
       this.flags.push(QueryFlag.DISTINCT);
     }
 
-    return this;
+    return this.init(QueryType.COUNT);
   }
 
-  join(field: string, alias: string, type: 'left' | 'inner' = 'inner'): this {
+  join(field: string, alias: string, type: 'leftJoin' | 'innerJoin' = 'innerJoin'): this {
     const [fromAlias, fromField] = this.helper.splitField(field);
     const entityName = this._aliasMap[fromAlias];
     const prop = this.metadata[entityName].properties[fromField];
@@ -99,7 +102,7 @@ export class QueryBuilder {
   }
 
   leftJoin(field: string, alias: string): this {
-    return this.join(field, alias, 'left');
+    return this.join(field, alias, 'leftJoin');
   }
 
   where(cond: Record<string, any>, operator?: keyof typeof QueryBuilderHelper.GROUP_OPERATORS): this;
@@ -191,7 +194,7 @@ export class QueryBuilder {
   }
 
   setLockMode(mode?: LockMode): this {
-    if ([LockMode.NONE, LockMode.PESSIMISTIC_READ, LockMode.PESSIMISTIC_WRITE].includes(mode!) && !this.driver.isInTransaction()) {
+    if ([LockMode.NONE, LockMode.PESSIMISTIC_READ, LockMode.PESSIMISTIC_WRITE].includes(mode!) && !this.context) {
       throw ValidationError.transactionRequired();
     }
 
@@ -200,52 +203,37 @@ export class QueryBuilder {
     return this;
   }
 
-  getQuery(): string {
+  getKnexQuery(): KnexQueryBuilder {
     this.finalize();
-    let sql = this.getQueryBase();
+    const qb = this.getQueryBase();
 
-    sql += this.helper.getClause('WHERE', this.helper.getQueryCondition(this.type, this._cond).join(' AND '), this._cond);
-    sql += this.helper.getClause('GROUP BY', this.prepareFields(this._groupBy), this._groupBy);
-    sql += this.helper.getClause('HAVING', this.helper.getQueryCondition(this.type, this._having).join(' AND '), this._having);
-    sql += this.helper.getClause('ORDER BY', this.helper.getQueryOrder(this.type, this._orderBy, this._populateMap).join(', '), this._orderBy);
-    sql += this.helper.getClause('LIMIT', '?', this._limit);
-    sql += this.helper.getClause('OFFSET', '?', this._offset);
+    Utils.runIfNotEmpty(() => this.helper.appendQueryCondition(this.type, this._cond, qb), this._cond);
+    Utils.runIfNotEmpty(() => qb.groupBy(this.prepareFields(this._groupBy)), this._groupBy);
+    Utils.runIfNotEmpty(() => this.helper.appendQueryCondition(this.type, this._having, qb, undefined, 'having'), this._having);
+    Utils.runIfNotEmpty(() => qb.orderBy(this.helper.getQueryOrder(this.type, this._orderBy, this._populateMap)), this._orderBy);
+    Utils.runIfNotEmpty(() => qb.limit(this._limit), this._limit);
+    Utils.runIfNotEmpty(() => qb.offset(this._offset), this._offset);
 
     if (this.type === QueryType.TRUNCATE && this.platform.usesCascadeStatement()) {
-      sql += ' CASCADE';
+      return this.knex.raw(qb.toSQL().toNative().sql + ' cascade') as any;
     }
 
-    sql += this.helper.getLockSQL(this.lockMode);
+    this.helper.getLockSQL(qb, this.lockMode);
+    this.helper.finalize(this.type, qb, this.metadata[this.entityName]);
 
-    return this.helper.finalize(this.type, sql, this.metadata[this.entityName]);
+    return qb;
+  }
+
+  getQuery(): string {
+    return this.getKnexQuery().toSQL().toNative().sql;
   }
 
   getParams(): any[] {
-    this.finalize();
-    let ret: any[] = [];
-
-    if (this.type === QueryType.INSERT && this._data) {
-      ret = Object.values(this._data);
-    } else if (this.type === QueryType.UPDATE) {
-      ret = Object.values(this._data);
-    }
-
-    ret = ret.concat(this.helper.getWhereParams(this._cond));
-    ret = ret.concat(this.helper.getWhereParams(this._having));
-
-    if (this._limit) {
-      ret.push(this._limit);
-    }
-
-    if (this._offset) {
-      ret.push(this._offset);
-    }
-
-    return SmartQueryHelper.processParams(ret);
+    return this.getKnexQuery().toSQL().toNative().bindings;
   }
 
   async execute(method: 'all' | 'get' | 'run' = 'all', mapResults = true): Promise<any> {
-    const res = await this.connection.execute(this.getQuery(), this.getParams(), method);
+    const res = await this.connection.execute(this.getKnexQuery(), [], method);
 
     if (!mapResults) {
       return res;
@@ -259,31 +247,31 @@ export class QueryBuilder {
   }
 
   clone(): QueryBuilder {
-    const qb = new QueryBuilder(this.entityName, this.metadata, this.driver, this.alias);
+    const qb = new QueryBuilder(this.entityName, this.metadata, this.driver, this.context, this.alias);
     Object.assign(qb, this);
 
     // clone array/object properties
     const properties = ['flags', '_fields', '_populate', '_populateMap', '_joins', '_aliasMap', '_cond', '_data', '_orderBy'];
     properties.forEach(prop => (qb as any)[prop] = Utils.copy(this[prop as keyof this]));
+    qb.finalized = false;
 
     return qb;
   }
 
-  private prepareFields(fields: string[], glue = ', '): string {
+  private prepareFields(fields: string[]): (string | Raw)[] {
     const ret: string[] = [];
 
     fields.forEach(f => {
       if (this._joins[f]) {
-        ret.push(...this.helper.mapJoinColumns(this.type, this._joins[f]));
-        return;
+        return ret.push(...this.helper.mapJoinColumns(this.type, this._joins[f]) as string[]);
       }
 
-      ret.push(this.helper.mapper(this.type, f));
+      ret.push(this.helper.mapper(this.type, f) as string);
     });
 
     Object.keys(this._populateMap).forEach(f => {
       if (!fields.includes(f)) {
-        ret.push(...this.helper.mapJoinColumns(this.type, this._joins[f]));
+        ret.push(...this.helper.mapJoinColumns(this.type, this._joins[f]) as string[]);
       }
 
       if (this._joins[f].prop.reference !== ReferenceType.ONE_TO_ONE) {
@@ -291,15 +279,7 @@ export class QueryBuilder {
       }
     });
 
-    if (this.flags.includes(QueryFlag.COUNT)) {
-      if (this.flags.includes(QueryFlag.DISTINCT)) {
-        return `COUNT(DISTINCT ${ret[0]}) AS ${this.helper.wrap('count')}`;
-      }
-
-      return `COUNT(${ret[0]}) AS ${this.helper.wrap('count')}`;
-    }
-
-    return ret.join(glue);
+    return ret;
   }
 
   private processWhere(cond: any): any {
@@ -335,7 +315,7 @@ export class QueryBuilder {
 
     this._fields.push(prop.name);
     const alias2 = `e${this.aliasCounter++}`;
-    this._joins[prop.name] = this.helper.joinOneToReference(prop, this.alias, alias2, 'left');
+    this._joins[prop.name] = this.helper.joinOneToReference(prop, this.alias, alias2, 'leftJoin');
     const prop2 = this.metadata[prop.type].properties[prop.mappedBy];
     Utils.renameKey(cond, prop.name, `${alias2}.${prop2.referenceColumnName}`);
   }
@@ -343,7 +323,7 @@ export class QueryBuilder {
   private processManyToMany(prop: EntityProperty, cond: any): void {
     const alias1 = `e${this.aliasCounter++}`;
     const join = {
-      type: 'left',
+      type: 'leftJoin',
       alias: alias1,
       ownerAlias: this.alias,
       joinColumn: prop.joinColumn,
@@ -364,7 +344,7 @@ export class QueryBuilder {
 
   private processOneToMany(prop: EntityProperty, cond: any): void {
     const alias2 = `e${this.aliasCounter++}`;
-    this._joins[prop.name] = this.helper.joinOneToReference(prop, this.alias, alias2, 'left');
+    this._joins[prop.name] = this.helper.joinOneToReference(prop, this.alias, alias2, 'leftJoin');
     Utils.renameKey(cond, prop.name, `${alias2}.${prop.referenceColumnName}`);
   }
 
@@ -383,36 +363,50 @@ export class QueryBuilder {
     return this;
   }
 
-  private getQueryBase(): string {
-    let sql = this.type + ' ';
+  private getQueryBase(): KnexQueryBuilder {
+    const qb = this.createBuilder();
 
     switch (this.type) {
       case QueryType.SELECT:
-        sql += this.flags.includes(QueryFlag.DISTINCT) && !this.flags.includes(QueryFlag.COUNT) ? 'DISTINCT ' : '';
-        sql += this.prepareFields(this._fields);
-        sql += ` FROM ${this.helper.getTableName(this.entityName, true)} AS ${this.helper.wrap(this.alias)}`;
-        sql += this.helper.processJoins(this._joins);
+        qb.select(this.prepareFields(this._fields));
+
+        if (this.flags.includes(QueryFlag.DISTINCT)) {
+          qb.distinct();
+        }
+
+        this.helper.processJoins(qb, this._joins);
+        break;
+      case QueryType.COUNT:
+        const m = this.flags.includes(QueryFlag.DISTINCT) ? 'countDistinct' : 'count';
+        qb[m](this.helper.mapper(this.type, this._fields[0], undefined, 'count'));
+        this.helper.processJoins(qb, this._joins);
         break;
       case QueryType.INSERT:
-        sql += `INTO ${this.helper.getTableName(this.entityName, true)}`;
-        sql += ' (' + Object.keys(this._data).map(k => this.helper.wrap(k)).join(', ') + ')';
-        sql += ' VALUES (' + Object.keys(this._data).map(() => '?').join(', ') + ')';
+        qb.insert(this._data);
         break;
       case QueryType.UPDATE:
-        sql += this.helper.getTableName(this.entityName, true);
-        const set = Object.keys(this._data).map(k => this.helper.wrap(k) + ' = ?');
-        this.helper.updateVersionProperty(set);
-        sql += ' SET ' + set.join(', ');
+        qb.update(this._data);
+        this.helper.updateVersionProperty(qb);
         break;
       case QueryType.DELETE:
-        sql += 'FROM ' + this.helper.getTableName(this.entityName, true);
+        qb.delete();
         break;
       case QueryType.TRUNCATE:
-        sql += 'TABLE ' + this.helper.getTableName(this.entityName, true);
+        qb.truncate();
         break;
     }
 
-    return sql;
+    return qb;
+  }
+
+  private createBuilder(): KnexQueryBuilder {
+    const tableName = this.helper.getTableName(this.entityName) + ([QueryType.SELECT, QueryType.COUNT].includes(this.type) ? ` as ${this.alias}` : '');
+    const qb = this.knex(tableName);
+
+    if (this.context) {
+      qb.transacting(this.context);
+    }
+    return qb;
   }
 
   private finalize(): void {
@@ -427,15 +421,16 @@ export class QueryBuilder {
 
       if (this.metadata[field]) { // pivot table entity
         const prop = this.metadata[field].properties[this.entityName];
-        this._joins[field] = this.helper.joinPivotTable(field, prop, this.alias, `e${this.aliasCounter++}`, 'left');
+        this._joins[field] = this.helper.joinPivotTable(field, prop, this.alias, `e${this.aliasCounter++}`, 'leftJoin');
         this._populateMap[field] = this._joins[field].alias;
       } else if (this.helper.isOneToOneInverse(field)) {
         const prop = this.metadata[this.entityName].properties[field];
-        this._joins[prop.name] = this.helper.joinOneToReference(prop, this.alias, `e${this.aliasCounter++}`, 'left');
+        this._joins[prop.name] = this.helper.joinOneToReference(prop, this.alias, `e${this.aliasCounter++}`, 'leftJoin');
         this._populateMap[field] = this._joins[field].alias;
       }
     });
 
+    SmartQueryHelper.processParams([this._data, this._cond, this._having]);
     this.finalized = true;
   }
 
@@ -443,7 +438,7 @@ export class QueryBuilder {
 
 export interface JoinOptions {
   table: string;
-  type: 'left' | 'inner';
+  type: 'leftJoin' | 'innerJoin';
   alias: string;
   ownerAlias: string;
   joinColumn?: string;

--- a/lib/query/enums.ts
+++ b/lib/query/enums.ts
@@ -1,13 +1,13 @@
 export enum QueryType {
   TRUNCATE = 'TRUNCATE',
   SELECT = 'SELECT',
+  COUNT = 'COUNT',
   INSERT = 'INSERT',
   UPDATE = 'UPDATE',
   DELETE = 'DELETE',
 }
 
 export enum QueryFlag {
-  COUNT = 'SELECT',
   DISTINCT = 'DISTINCT',
 }
 

--- a/lib/schema/MySqlSchemaHelper.ts
+++ b/lib/schema/MySqlSchemaHelper.ts
@@ -1,5 +1,6 @@
 import { SchemaHelper } from './SchemaHelper';
 import { EntityProperty } from '../decorators';
+import { MySqlTableBuilder } from 'knex';
 
 export class MySqlSchemaHelper extends SchemaHelper {
 
@@ -20,28 +21,21 @@ export class MySqlSchemaHelper extends SchemaHelper {
     date: 0,
   };
 
-  getIdentifierQuoteCharacter(): string {
-    return '`';
-  }
-
   getSchemaBeginning(): string {
-    return 'SET NAMES utf8;\nSET FOREIGN_KEY_CHECKS=0;\n\n\n';
+    return 'set names utf8;\nset foreign_key_checks = 0;\n\n';
   }
 
   getSchemaEnd(): string {
-    return 'SET FOREIGN_KEY_CHECKS=1;\n';
+    return 'set foreign_key_checks = 1;\n';
   }
 
-  getSchemaTableEnd(): string {
-    return ' ENGINE=InnoDB DEFAULT CHARSET=utf8';
+  finalizeTable(table: MySqlTableBuilder): void {
+    table.engine('InnoDB');
+    table.charset('utf8');
   }
 
   getTypeDefinition(prop: EntityProperty): string {
     return super.getTypeDefinition(prop, MySqlSchemaHelper.TYPES, MySqlSchemaHelper.DEFAULT_TYPE_LENGTHS);
-  }
-
-  getUnsignedSuffix(prop: EntityProperty): string {
-    return ' unsigned';
   }
 
 }

--- a/lib/schema/PostgreSqlSchemaHelper.ts
+++ b/lib/schema/PostgreSqlSchemaHelper.ts
@@ -1,5 +1,5 @@
 import { SchemaHelper } from './SchemaHelper';
-import { EntityMetadata, EntityProperty } from '../decorators';
+import { EntityProperty } from '../decorators';
 
 export class PostgreSqlSchemaHelper extends SchemaHelper {
 
@@ -20,38 +20,19 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   };
 
   getSchemaBeginning(): string {
-    return `SET NAMES 'utf8';\nSET session_replication_role = 'replica';\n\n\n`;
+    return `set names 'utf8';\nset session_replication_role = 'replica';\n\n`;
   }
 
   getSchemaEnd(): string {
-    return `SET session_replication_role = 'origin';\n`;
-  }
-
-  getAutoIncrementStatement(meta: EntityMetadata): string {
-    return `DEFAULT NEXTVAL('${meta.collection}_seq')`;
+    return `set session_replication_role = 'origin';\n`;
   }
 
   getTypeDefinition(prop: EntityProperty): string {
     return super.getTypeDefinition(prop, PostgreSqlSchemaHelper.TYPES, PostgreSqlSchemaHelper.DEFAULT_TYPE_LENGTHS);
   }
 
-  getUnsignedSuffix(prop: EntityProperty): string {
-    return ` check (${this.quoteIdentifier(prop.fieldName)} > 0)`;
-  }
-
-  supportsSequences(): boolean {
-    return true;
-  }
-
   indexForeignKeys() {
     return false;
-  }
-
-  dropTable(meta: EntityMetadata): string {
-    let ret = `DROP TABLE IF EXISTS ${this.quoteIdentifier(meta.collection)} CASCADE;\n`;
-    ret += `DROP SEQUENCE IF EXISTS ${this.quoteIdentifier(meta.collection + '_seq')};\n`;
-
-    return ret;
   }
 
 }

--- a/lib/schema/SchemaHelper.ts
+++ b/lib/schema/SchemaHelper.ts
@@ -1,10 +1,7 @@
-import { EntityMetadata, EntityProperty } from '../decorators';
+import { TableBuilder } from 'knex';
+import { EntityProperty } from '../decorators';
 
 export abstract class SchemaHelper {
-
-  getIdentifierQuoteCharacter(): string {
-    return '"';
-  }
 
   getSchemaBeginning(): string {
     return '';
@@ -14,16 +11,8 @@ export abstract class SchemaHelper {
     return '';
   }
 
-  getSchemaTableEnd(): string {
-    return '';
-  }
-
-  getAutoIncrementStatement(meta: EntityMetadata): string {
-    return 'AUTO_INCREMENT';
-  }
-
-  getPrimaryKeySubtype(meta: EntityMetadata): string {
-    return 'NOT NULL';
+  finalizeTable(table: TableBuilder): void {
+    //
   }
 
   getTypeDefinition(prop: EntityProperty, types: Record<string, string> = {}, lengths: Record<string, number> = {}): string {
@@ -38,73 +27,12 @@ export abstract class SchemaHelper {
     return type;
   }
 
-  getUnsignedSuffix(prop: EntityProperty): string {
-    return '';
-  }
-
   supportsSchemaConstraints(): boolean {
     return true;
   }
 
-  supportsSchemaMultiAlter(): boolean {
-    return true;
-  }
-
-  supportsSequences(): boolean {
-    return false;
-  }
-
-  quoteIdentifier(field: string): string {
-    const quoteChar = this.getIdentifierQuoteCharacter();
-    return quoteChar + field + quoteChar;
-  }
-
-  dropTable(meta: EntityMetadata): string {
-    const pkProp = meta.properties[meta.primaryKey];
-    let ret = `DROP TABLE IF EXISTS ${this.quoteIdentifier(meta.collection)};\n`;
-
-    if (this.supportsSequences() && pkProp.type === 'number') {
-      ret += `DROP SEQUENCE IF EXISTS ${this.quoteIdentifier(meta.collection + '_seq')};\n`;
-    }
-
-    return ret;
-  }
-
   indexForeignKeys() {
     return true;
-  }
-
-  createPrimaryKeyColumn(meta: EntityMetadata, prop: EntityProperty): string {
-    let ret = ' ' + this.getPrimaryKeySubtype(meta);
-
-    if (prop.type === 'number') {
-      ret += ' ' + this.getAutoIncrementStatement(meta);
-    }
-
-    return ret;
-  }
-
-  createColumn(meta: EntityMetadata, prop: EntityProperty, nullable: boolean): string {
-    let ret = '';
-
-    if (prop.unique) {
-      ret += ' UNIQUE';
-    }
-
-    if (!nullable) {
-      ret += ' NOT NULL';
-    }
-
-    // support falsy default values like `0`, `false or empty string
-    if (typeof prop.default !== 'undefined') {
-      return ret + ` DEFAULT ${prop.default}`;
-    }
-
-    if (nullable) {
-      return ret + ` DEFAULT NULL`;
-    }
-
-    return ret;
   }
 
 }

--- a/lib/schema/SqliteSchemaHelper.ts
+++ b/lib/schema/SqliteSchemaHelper.ts
@@ -1,29 +1,21 @@
 import { SchemaHelper } from './SchemaHelper';
-import { EntityMetadata, EntityProperty } from '../decorators';
+import { EntityProperty } from '../decorators';
 
 export class SqliteSchemaHelper extends SchemaHelper {
 
   static readonly TYPES = {
-    number: 'INTEGER',
-    boolean: 'INTEGER',
-    date: 'TEXT',
-    string: 'TEXT',
+    number: 'integer',
+    boolean: 'integer',
+    date: 'text',
+    string: 'text',
   };
 
-  getAutoIncrementStatement(meta: EntityMetadata): string {
-    return 'AUTOINCREMENT';
-  }
-
   getSchemaBeginning(): string {
-    return 'PRAGMA foreign_keys=OFF;\n\n\n';
+    return 'pragma foreign_keys = off;\n\n';
   }
 
   getSchemaEnd(): string {
-    return 'PRAGMA foreign_keys=ON;\n';
-  }
-
-  getPrimaryKeySubtype(meta: EntityMetadata): string {
-    return 'PRIMARY KEY';
+    return 'pragma foreign_keys = on;\n';
   }
 
   getTypeDefinition(prop: EntityProperty): string {
@@ -32,10 +24,6 @@ export class SqliteSchemaHelper extends SchemaHelper {
   }
 
   supportsSchemaConstraints(): boolean {
-    return false;
-  }
-
-  supportsSchemaMultiAlter(): boolean {
     return false;
   }
 

--- a/lib/utils/Configuration.ts
+++ b/lib/utils/Configuration.ts
@@ -10,11 +10,13 @@ import { Logger, Utils } from '../utils';
 import { EntityManager } from '../EntityManager';
 import { IDatabaseDriver } from '..';
 import { Platform } from '../platforms';
+import { PoolConfig } from 'knex';
 
 export class Configuration {
 
   static readonly DEFAULTS = {
     type: 'mongo',
+    pool: {},
     entities: [],
     entitiesDirs: [],
     entitiesDirsTs: [],
@@ -167,6 +169,7 @@ export interface MikroORMOptions {
   user?: string;
   password?: string;
   multipleStatements?: boolean; // for mysql driver
+  pool: PoolConfig,
   strict: boolean;
   logger: (message: string) => void;
   debug: boolean;

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -31,10 +31,6 @@ export class Utils {
     return [...new Set(items)];
   }
 
-  static flatten<T>(arrays: T[][]): T[] {
-    return [].concat(...arrays as any[]);
-  }
-
   static merge(target: any, ...sources: any[]): any {
     if (!sources.length) {
       return target;
@@ -241,6 +237,12 @@ export class Utils {
 
   static normalizePath(...parts: string[]): string {
     return parts.join('/').replace(/\\/g, '/');
+  }
+
+  static runIfNotEmpty(clause: () => any, data: any): void {
+    if (!Utils.isEmpty(data)) {
+      clause();
+    }
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "fast-deep-equal": "^2.0.0",
     "fs-extra": "^8.0.0",
     "globby": "^10.0.0",
+    "knex": "^0.19.0",
     "ts-morph": "^3.0.0",
     "typescript": "^3.5.0",
     "uuid": "^3.3.2"
@@ -92,6 +93,20 @@
     "mysql2": "^1.6.0",
     "pg": "^7.10.0",
     "sqlite": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "mongodb": {
+      "optional": true
+    },
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    },
+    "sqlite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1245,9 +1245,7 @@ describe('EntityManagerMongo', () => {
   });
 
   test('EM do not support transactions', async () => {
-    await expect(orm.em.beginTransaction()).rejects.toThrowError('Transactions are not supported by current driver');
-    await expect(orm.em.rollback()).rejects.toThrowError('Transactions are not supported by current driver');
-    await expect(orm.em.commit()).rejects.toThrowError('Transactions are not supported by current driver');
+    await expect(orm.em.transactional(async em => em)).rejects.toThrowError('Transactions are not supported by current driver');
   });
 
   test('loading connected entity will not update identity map for associations', async () => {

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -14,35 +14,35 @@ describe('QueryBuilder', () => {
   test('select query', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*').where({ name: 'test 123', type: PublisherType.GLOBAL }).orderBy({ name: QueryOrder.DESC, type: QueryOrder.ASC }).limit(2, 1);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE `e0`.`name` = ? AND `e0`.`type` = ? ORDER BY `e0`.`name` DESC, `e0`.`type` ASC LIMIT ? OFFSET ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` = ? and `e0`.`type` = ? order by `e0`.`name` desc, `e0`.`type` asc limit ? offset ?');
     expect(qb.getParams()).toEqual(['test 123', PublisherType.GLOBAL, 2, 1]);
   });
 
   test('select where is null', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*').where({ type: null }).limit(2, 1);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE `e0`.`type` IS NULL LIMIT ? OFFSET ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`type` is null limit ? offset ?');
     expect(qb.getParams()).toEqual([2, 1]);
   });
 
   test('select query with order by variants', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*').where({ name: 'test 123' }).orderBy({ a: QueryOrder.DESC, b: 'ASC', c: 'desc', d: -1 }).limit(2, 1);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE `e0`.`name` = ? ORDER BY `e0`.`a` DESC, `e0`.`b` ASC, `e0`.`c` desc, `e0`.`d` DESC LIMIT ? OFFSET ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` = ? order by `e0`.`a` desc, `e0`.`b` asc, `e0`.`c` desc, `e0`.`d` desc limit ? offset ?');
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
 
   test('select constant expression', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('1').where({ id: 123 });
-    expect(qb.getQuery()).toEqual('SELECT 1 FROM `publisher2` AS `e0` WHERE `e0`.`id` = ?');
+    expect(qb.getQuery()).toEqual('select 1 from `publisher2` as `e0` where `e0`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select in query', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.select(['id', 'name', 'type']).where({ name: { $in: ['test 123', 'lol 321'] }, type: PublisherType.GLOBAL }).limit(2, 1);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.`id`, `e0`.`name`, `e0`.`type` FROM `publisher2` AS `e0` WHERE `e0`.`name` IN (?, ?) AND `e0`.`type` = ? LIMIT ? OFFSET ?');
+    expect(qb.getQuery()).toEqual('select `e0`.`id`, `e0`.`name`, `e0`.`type` from `publisher2` as `e0` where `e0`.`name` in (?, ?) and `e0`.`type` = ? limit ? offset ?');
     expect(qb.getParams()).toEqual(['test 123', 'lol 321', PublisherType.GLOBAL, 2, 1]);
   });
 
@@ -53,7 +53,7 @@ describe('QueryBuilder', () => {
       .andWhere({ type: PublisherType.GLOBAL })
       .orWhere({ name: 'lol 321' })
       .limit(2, 1);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE ((`e0`.`name` = ? AND `e0`.`type` = ?) OR `e0`.`name` = ?) LIMIT ? OFFSET ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where ((`e0`.`name` = ? and `e0`.`type` = ?) or `e0`.`name` = ?) limit ? offset ?');
     expect(qb.getParams()).toEqual(['test 123', PublisherType.GLOBAL, 'lol 321', 2, 1]);
   });
 
@@ -63,7 +63,7 @@ describe('QueryBuilder', () => {
       .andWhere({ type: PublisherType.GLOBAL })
       .orWhere({ name: 'lol 321' })
       .limit(2, 1);
-    expect(qb1.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE (`e0`.`type` = ? OR `e0`.`name` = ?) LIMIT ? OFFSET ?');
+    expect(qb1.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where (`e0`.`type` = ? or `e0`.`name` = ?) limit ? offset ?');
     expect(qb1.getParams()).toEqual([PublisherType.GLOBAL, 'lol 321', 2, 1]);
 
     const qb2 = orm.em.createQueryBuilder(Publisher2)
@@ -71,7 +71,7 @@ describe('QueryBuilder', () => {
       .orWhere({ name: 'lol 321' })
       .andWhere({ type: PublisherType.GLOBAL })
       .limit(2, 1);
-    expect(qb2.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE (`e0`.`name` = ? AND `e0`.`type` = ?) LIMIT ? OFFSET ?');
+    expect(qb2.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where (`e0`.`name` = ? and `e0`.`type` = ?) limit ? offset ?');
     expect(qb2.getParams()).toEqual(['lol 321', PublisherType.GLOBAL, 2, 1]);
   });
 
@@ -83,7 +83,7 @@ describe('QueryBuilder', () => {
       .andWhere({ name: 'test 321' })
       .andWhere({ name: 'lol 321' })
       .limit(2, 1);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE (`e0`.`name` = ? AND `e0`.`type` = ? AND `e0`.`name` = ? AND `e0`.`name` = ?) LIMIT ? OFFSET ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where (`e0`.`name` = ? and `e0`.`type` = ? and `e0`.`name` = ? and `e0`.`name` = ?) limit ? offset ?');
     expect(qb.getParams()).toEqual(['test 123', PublisherType.GLOBAL, 'test 321', 'lol 321', 2, 1]);
   });
 
@@ -95,7 +95,7 @@ describe('QueryBuilder', () => {
       .orWhere({ name: 'test 321' })
       .orWhere({ name: 'lol 321' })
       .limit(2, 1);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE (`e0`.`name` = ? OR `e0`.`type` = ? OR `e0`.`name` = ? OR `e0`.`name` = ?) LIMIT ? OFFSET ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where (`e0`.`name` = ? or `e0`.`type` = ? or `e0`.`name` = ? or `e0`.`name` = ?) limit ? offset ?');
     expect(qb.getParams()).toEqual(['test 123', PublisherType.GLOBAL, 'test 321', 'lol 321', 2, 1]);
   });
 
@@ -105,10 +105,10 @@ describe('QueryBuilder', () => {
       .leftJoin('fb.baz', 'fz')
       .where({ 'fz.name': 'test 123' })
       .limit(2, 1);
-    const sql = 'SELECT `fb`.*, `fz`.* FROM `foo_bar2` AS `fb` ' +
-      'LEFT JOIN `foo_baz2` AS `fz` ON `fb`.`baz_id` = `fz`.`id` ' +
-      'WHERE `fz`.`name` = ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `fb`.*, `fz`.* from `foo_bar2` as `fb` ' +
+      'left join `foo_baz2` as `fz` on `fb`.`baz_id` = `fz`.`id` ' +
+      'where `fz`.`name` = ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
@@ -119,10 +119,10 @@ describe('QueryBuilder', () => {
       .leftJoin('fz.bar', 'fb')
       .where({ 'fb.name': 'test 123' })
       .limit(2, 1);
-    const sql = 'SELECT `fb`.*, `fz`.* FROM `foo_baz2` AS `fz` ' +
-      'LEFT JOIN `foo_bar2` AS `fb` ON `fz`.`id` = `fb`.`baz_id` ' +
-      'WHERE `fb`.`name` = ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `fb`.*, `fz`.* from `foo_baz2` as `fz` ' +
+      'left join `foo_bar2` as `fb` on `fz`.`id` = `fb`.`baz_id` ' +
+      'where `fb`.`name` = ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
@@ -133,10 +133,10 @@ describe('QueryBuilder', () => {
       .leftJoin('b.author', 'a')
       .where({ 'a.name': 'test 123' })
       .limit(2, 1);
-    const sql = 'SELECT `a`.*, `b`.* FROM `book2` AS `b` ' +
-      'LEFT JOIN `author2` AS `a` ON `b`.`author_id` = `a`.`id` ' +
-      'WHERE `a`.`name` = ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `a`.*, `b`.* from `book2` as `b` ' +
+      'left join `author2` as `a` on `b`.`author_id` = `a`.`id` ' +
+      'where `a`.`name` = ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
@@ -147,10 +147,10 @@ describe('QueryBuilder', () => {
       .leftJoin('a.books', 'b')
       .where({ 'b.title': 'test 123' })
       .limit(2, 1);
-    const sql = 'SELECT `a`.*, `b`.* FROM `author2` AS `a` ' +
-      'LEFT JOIN `book2` AS `b` ON `a`.`id` = `b`.`author_id` ' +
-      'WHERE `b`.`title` = ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `a`.*, `b`.* from `author2` as `a` ' +
+      'left join `book2` as `b` on `a`.`id` = `b`.`author_id` ' +
+      'where `b`.`title` = ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
@@ -161,11 +161,11 @@ describe('QueryBuilder', () => {
       .leftJoin('b.tags', 't')
       .where({ 't.name': 'test 123' })
       .limit(2, 1);
-    const sql = 'SELECT `b`.*, `t`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` FROM `book2` AS `b` ' +
-      'LEFT JOIN `book2_to_book_tag2` AS `e1` ON `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
-      'LEFT JOIN `book_tag2` AS `t` ON `e1`.`book_tag2_id` = `t`.`id` ' +
-      'WHERE `t`.`name` = ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `b`.*, `t`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` from `book2` as `b` ' +
+      'left join `book2_to_book_tag2` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
+      'left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` ' +
+      'where `t`.`name` = ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
@@ -176,11 +176,11 @@ describe('QueryBuilder', () => {
       .leftJoin('t.books', 'b')
       .where({ 'b.title': 'test 123' })
       .limit(2, 1);
-    const sql = 'SELECT `b`.*, `t`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` FROM `book_tag2` AS `t` ' +
-      'LEFT JOIN `book2_to_book_tag2` AS `e1` ON `t`.`id` = `e1`.`book_tag2_id` ' +
-      'LEFT JOIN `book2` AS `b` ON `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
-      'WHERE `b`.`title` = ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `b`.*, `t`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` from `book_tag2` as `t` ' +
+      'left join `book2_to_book_tag2` as `e1` on `t`.`id` = `e1`.`book_tag2_id` ' +
+      'left join `book2` as `b` on `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
+      'where `b`.`title` = ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
@@ -193,13 +193,13 @@ describe('QueryBuilder', () => {
       .join('b.tags', 't')
       .where({ 'p.name': 'test 123', 'b.title': /3$/ })
       .limit(2, 1);
-    const sql = 'SELECT `p`.*, `b`.*, `a`.*, `t`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` FROM `publisher2` AS `p` ' +
-      'LEFT JOIN `book2` AS `b` ON `p`.`id` = `b`.`publisher_id` ' +
-      'JOIN `author2` AS `a` ON `b`.`author_id` = `a`.`id` ' +
-      'JOIN `book2_to_book_tag2` AS `e1` ON `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
-      'JOIN `book_tag2` AS `t` ON `e1`.`book_tag2_id` = `t`.`id` ' +
-      'WHERE `p`.`name` = ? AND `b`.`title` LIKE ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `p`.*, `b`.*, `a`.*, `t`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` from `publisher2` as `p` ' +
+      'left join `book2` as `b` on `p`.`id` = `b`.`publisher_id` ' +
+      'inner join `author2` as `a` on `b`.`author_id` = `a`.`id` ' +
+      'inner join `book2_to_book_tag2` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
+      'inner join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` ' +
+      'where `p`.`name` = ? and `b`.`title` like ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', '%3', 2, 1]);
   });
@@ -207,121 +207,121 @@ describe('QueryBuilder', () => {
   test('select with boolean', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
     qb.select('*').where({ termsAccepted: false });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `author2` AS `e0` WHERE `e0`.`terms_accepted` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `author2` as `e0` where `e0`.`terms_accepted` = ?');
     expect(qb.getParams()).toEqual([false]);
   });
 
   test('select with custom expression', async () => {
     const qb1 = orm.em.createQueryBuilder(Book2);
-    qb1.select('*').where({ 'JSON_CONTAINS(`e0`.`meta`, ?)': [{ foo: 'bar' }, true] });
-    expect(qb1.getQuery()).toEqual('SELECT `e0`.* FROM `book2` AS `e0` WHERE JSON_CONTAINS(`e0`.`meta`, ?) = ?');
-    expect(qb1.getParams()).toEqual(['{"foo":"bar"}', true]);
+    qb1.select('*').where({ 'JSON_CONTAINS(`e0`.`meta`, ?)': [{ foo: 'bar' }] });
+    expect(qb1.getQuery()).toEqual('select `e0`.* from `book2` as `e0` where JSON_CONTAINS(`e0`.`meta`, ?)');
+    expect(qb1.getParams()).toEqual(['{"foo":"bar"}']);
 
     const qb2 = orm.em.createQueryBuilder(Book2);
-    qb2.select('*').where({ 'JSON_CONTAINS(`e0`.`meta`, ?)': [{ foo: 'baz' }, false] });
-    expect(qb2.getQuery()).toEqual('SELECT `e0`.* FROM `book2` AS `e0` WHERE JSON_CONTAINS(`e0`.`meta`, ?) = ?');
+    qb2.select('*').where({ 'JSON_CONTAINS(`e0`.`meta`, ?) = ?': [{ foo: 'baz' }, false] });
+    expect(qb2.getQuery()).toEqual('select `e0`.* from `book2` as `e0` where JSON_CONTAINS(`e0`.`meta`, ?) = ?');
     expect(qb2.getParams()).toEqual(['{"foo":"baz"}', false]);
   });
 
   test('select by regexp', async () => {
     let qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*').where({ name: /test/ });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE `e0`.`name` LIKE ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` like ?');
     expect(qb.getParams()).toEqual(['%test%']);
 
     qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*').where({ name: /^test/ });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE `e0`.`name` LIKE ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` like ?');
     expect(qb.getParams()).toEqual(['test%']);
 
     qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*').where({ name: /t.st$/ });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE `e0`.`name` LIKE ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` like ?');
     expect(qb.getParams()).toEqual(['%t_st']);
 
     qb = orm.em.createQueryBuilder(Publisher2);
     qb.select('*').where({ name: /^c.o.*l-te.*st\.c.m$/ });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `publisher2` AS `e0` WHERE `e0`.`name` LIKE ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `publisher2` as `e0` where `e0`.`name` like ?');
     expect(qb.getParams()).toEqual(['c_o%l-te%st.c_m']);
   });
 
   test('select by m:1', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
     qb.select('*').where({ favouriteBook: 123 });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `author2` AS `e0` WHERE `e0`.`favourite_book_uuid_pk` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `author2` as `e0` where `e0`.`favourite_book_uuid_pk` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by 1:m', async () => {
     const qb = orm.em.createQueryBuilder(Author2);
     qb.select('*').where({ books: { $in: [123, 321] } });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `author2` AS `e0` LEFT JOIN `book2` AS `e1` ON `e0`.`id` = `e1`.`author_id` WHERE `e1`.`id` IN (?, ?)');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `author2` as `e0` left join `book2` as `e1` on `e0`.`id` = `e1`.`author_id` where `e1`.`id` in (?, ?)');
     expect(qb.getParams()).toEqual([123, 321]);
   });
 
   test('select by 1:1', async () => {
     const qb = orm.em.createQueryBuilder(FooBar2);
     qb.select('*').where({ baz: 123 });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `foo_bar2` AS `e0` WHERE `e0`.`baz_id` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `foo_bar2` as `e0` where `e0`.`baz_id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by 1:1 inversed', async () => {
     const qb = orm.em.createQueryBuilder(FooBaz2);
     qb.select('*').where({ bar: 123 });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.*, `e1`.`id` AS `bar_id` FROM `foo_baz2` AS `e0` LEFT JOIN `foo_bar2` AS `e1` ON `e0`.`id` = `e1`.`baz_id` WHERE `e1`.`id` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `bar_id` from `foo_baz2` as `e0` left join `foo_bar2` as `e1` on `e0`.`id` = `e1`.`baz_id` where `e1`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by 1:1 inversed with populate', async () => {
     const qb = orm.em.createQueryBuilder(FooBaz2);
     qb.select('*').where({ id: 123 }).populate(['bar']);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.*, `e1`.`id` AS `bar_id` FROM `foo_baz2` AS `e0` LEFT JOIN `foo_bar2` AS `e1` ON `e0`.`id` = `e1`.`baz_id` WHERE `e0`.`id` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `bar_id` from `foo_baz2` as `e0` left join `foo_bar2` as `e1` on `e0`.`id` = `e1`.`baz_id` where `e0`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by 1:1 inversed (uuid pk)', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
     qb.select('*').where({ test: 123 });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.*, `e1`.`id` AS `test_id` FROM `book2` AS `e0` LEFT JOIN `test2` AS `e1` ON `e0`.`uuid_pk` = `e1`.`book_uuid_pk` WHERE `e1`.`id` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `test_id` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by 1:1 inversed with populate (uuid pk)', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
     qb.select('*').where({ test: 123 }).populate(['test']);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.*, `e1`.`id` AS `test_id` FROM `book2` AS `e0` LEFT JOIN `test2` AS `e1` ON `e0`.`uuid_pk` = `e1`.`book_uuid_pk` WHERE `e1`.`id` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `test_id` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by 1:1 inversed with populate() before where() (uuid pk)', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
     qb.select('*').populate(['test']).where({ test: 123 });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.*, `e1`.`id` AS `test_id` FROM `book2` AS `e0` LEFT JOIN `test2` AS `e1` ON `e0`.`uuid_pk` = `e1`.`book_uuid_pk` WHERE `e1`.`id` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`id` as `test_id` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by m:n', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
     qb.select('*').where({ tags: 123 });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` FROM `book2` AS `e0` LEFT JOIN `book2_to_book_tag2` AS `e1` ON `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` WHERE `e1`.`book_tag2_id` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` from `book2` as `e0` left join `book2_to_book_tag2` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` where `e1`.`book_tag2_id` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by m:n inversed', async () => {
     const qb = orm.em.createQueryBuilder(BookTag2);
     qb.select('*').where({ books: 123 });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` FROM `book_tag2` AS `e0` LEFT JOIN `book2_to_book_tag2` AS `e1` ON `e0`.`id` = `e1`.`book_tag2_id` WHERE `e1`.`book2_uuid_pk` = ?');
+    expect(qb.getQuery()).toEqual('select `e0`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` from `book_tag2` as `e0` left join `book2_to_book_tag2` as `e1` on `e0`.`id` = `e1`.`book_tag2_id` where `e1`.`book2_uuid_pk` = ?');
     expect(qb.getParams()).toEqual([123]);
   });
 
   test('select by m:n with populate', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
     qb.select('*').populate(['publisher2_to_test2']).where({ publisher2_id: { $in: [ 1, 2 ] } }).orderBy({ 'publisher2_to_test2.id': QueryOrder.ASC });
-    let sql = 'SELECT `e0`.*, `e1`.`test2_id`, `e1`.`publisher2_id` FROM `test2` AS `e0`';
-    sql += ' LEFT JOIN `publisher2_to_test2` AS `e1` ON `e0`.`id` = `e1`.`test2_id`';
-    sql += ' WHERE `e1`.`publisher2_id` IN (?, ?)';
-    sql += ' ORDER BY `e1`.`id` ASC';
+    let sql = 'select `e0`.*, `e1`.`test2_id`, `e1`.`publisher2_id` from `test2` as `e0`';
+    sql += ' left join `publisher2_to_test2` as `e1` on `e0`.`id` = `e1`.`test2_id`';
+    sql += ' where `e1`.`publisher2_id` in (?, ?)';
+    sql += ' order by `e1`.`id` asc';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual([1, 2]);
   });
@@ -329,21 +329,21 @@ describe('QueryBuilder', () => {
   test('select by m:n with unknown populate ignored', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
     qb.select('*').populate(['not_existing']);
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `test2` AS `e0`');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0`');
     expect(qb.getParams()).toEqual([]);
   });
 
   test('select with operator (simple)', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
     qb.select('*').where({ id: { $nin: [3, 4] } });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `test2` AS `e0` WHERE `e0`.`id` NOT IN (?, ?)');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0` where `e0`.`id` not in (?, ?)');
     expect(qb.getParams()).toEqual([3, 4]);
   });
 
   test('select with operator (wrapped)', async () => {
     const qb1 = orm.em.createQueryBuilder(Test2);
     qb1.select('*').where({ $and: [{ id: { $nin: [3, 4] } }, { id: { $gt: 2 } }] });
-    expect(qb1.getQuery()).toEqual('SELECT `e0`.* FROM `test2` AS `e0` WHERE (`e0`.`id` NOT IN (?, ?) AND `e0`.`id` > ?)');
+    expect(qb1.getQuery()).toEqual('select `e0`.* from `test2` as `e0` where (`e0`.`id` not in (?, ?) and `e0`.`id` > ?)');
     expect(qb1.getParams()).toEqual([3, 4, 2]);
 
     const qb2 = orm.em.createQueryBuilder(Test2);
@@ -352,30 +352,31 @@ describe('QueryBuilder', () => {
     expect(qb2.getParams()).toEqual(qb1.getParams());
   });
 
-  test('select with operator (NOT)', async () => {
+  test('select with operator (not)', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
     qb.select('*').where({ $not: { id: { $in: [3, 4] } } });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `test2` AS `e0` WHERE NOT (`e0`.`id` IN (?, ?))');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0` where not (`e0`.`id` in (?, ?))');
     expect(qb.getParams()).toEqual([3, 4]);
   });
 
   test('select with unsupported operator', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
     qb.select('*').where({ $test: { foo: 'bar'} });
-    expect(qb.getParams()).toEqual([{ foo: 'bar'}]);
+    expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0`');
+    expect(qb.getParams()).toEqual([]);
   });
 
   test('select distinct id with left join', async () => {
     const qb = orm.em.createQueryBuilder(BookTag2, 't');
-    qb.select(['DISTINCT b.uuid_pk', 'b.*', 't.*'])
+    qb.select(['distinct b.uuid_pk', 'b.*', 't.*'])
       .leftJoin('t.books', 'b')
       .where({ 'b.title': 'test 123' })
       .limit(2, 1);
-    const sql = 'SELECT DISTINCT b.uuid_pk, `b`.*, `t`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` FROM `book_tag2` AS `t` ' +
-      'LEFT JOIN `book2_to_book_tag2` AS `e1` ON `t`.`id` = `e1`.`book_tag2_id` ' +
-      'LEFT JOIN `book2` AS `b` ON `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
-      'WHERE `b`.`title` = ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select distinct b.uuid_pk, `b`.*, `t`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` from `book_tag2` as `t` ' +
+      'left join `book2_to_book_tag2` as `e1` on `t`.`id` = `e1`.`book_tag2_id` ' +
+      'left join `book2` as `b` on `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
+      'where `b`.`title` = ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
@@ -386,11 +387,11 @@ describe('QueryBuilder', () => {
       .leftJoin('t.books', 'b')
       .where({ 'b.title': 'test 123' })
       .limit(2, 1);
-    const sql = 'SELECT DISTINCT `b`.`uuid_pk`, `b`.*, `t`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` FROM `book_tag2` AS `t` ' +
-      'LEFT JOIN `book2_to_book_tag2` AS `e1` ON `t`.`id` = `e1`.`book_tag2_id` ' +
-      'LEFT JOIN `book2` AS `b` ON `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
-      'WHERE `b`.`title` = ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select distinct `b`.`uuid_pk`, `b`.*, `t`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` from `book_tag2` as `t` ' +
+      'left join `book2_to_book_tag2` as `e1` on `t`.`id` = `e1`.`book_tag2_id` ' +
+      'left join `book2` as `b` on `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
+      'where `b`.`title` = ? ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 2, 1]);
   });
@@ -399,58 +400,58 @@ describe('QueryBuilder', () => {
     const qb = orm.em.createQueryBuilder(BookTag2, 't');
     qb.select(['b.*', 't.*'])
       .leftJoin('t.books', 'b')
-      .where('b.title = ? OR b.title = ?', ['test 123', 'lol 321'])
+      .where('b.title = ? or b.title = ?', ['test 123', 'lol 321'])
       .andWhere('1 = 1')
       .orWhere('1 = 2')
       .limit(2, 1);
-    const sql = 'SELECT `b`.*, `t`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` FROM `book_tag2` AS `t` ' +
-      'LEFT JOIN `book2_to_book_tag2` AS `e1` ON `t`.`id` = `e1`.`book_tag2_id` ' +
-      'LEFT JOIN `book2` AS `b` ON `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
-      'WHERE (((b.title = ? OR b.title = ?) AND (1 = 1)) OR (1 = 2)) ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `b`.*, `t`.*, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` from `book_tag2` as `t` ' +
+      'left join `book2_to_book_tag2` as `e1` on `t`.`id` = `e1`.`book_tag2_id` ' +
+      'left join `book2` as `b` on `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
+      'where (((b.title = ? or b.title = ?) and (1 = 1)) or (1 = 2)) ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 'lol 321', 2, 1]);
   });
 
   test('select with group by and having', async () => {
     const qb = orm.em.createQueryBuilder(BookTag2, 't');
-    qb.select(['b.*', 't.*', 'COUNT(t.id) as tags'])
+    qb.select(['b.*', 't.*', 'count(t.id) as tags'])
       .leftJoin('t.books', 'b')
-      .where('b.title = ? OR b.title = ?', ['test 123', 'lol 321'])
+      .where('b.title = ? or b.title = ?', ['test 123', 'lol 321'])
       .groupBy('b.uuid')
       .having('tags > ?', [0])
       .limit(2, 1);
-    const sql = 'SELECT `b`.*, `t`.*, COUNT(t.id) as tags, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` FROM `book_tag2` AS `t` ' +
-      'LEFT JOIN `book2_to_book_tag2` AS `e1` ON `t`.`id` = `e1`.`book_tag2_id` ' +
-      'LEFT JOIN `book2` AS `b` ON `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
-      'WHERE (b.title = ? OR b.title = ?) ' +
-      'GROUP BY `b`.`uuid_pk` ' +
-      'HAVING (tags > ?) ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `b`.*, `t`.*, count(t.id) as tags, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` from `book_tag2` as `t` ' +
+      'left join `book2_to_book_tag2` as `e1` on `t`.`id` = `e1`.`book_tag2_id` ' +
+      'left join `book2` as `b` on `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
+      'where (b.title = ? or b.title = ?) ' +
+      'group by `b`.`uuid_pk` ' +
+      'having (tags > ?) ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', 'lol 321', 0, 2, 1]);
   });
 
   test('select with group by and having with object', async () => {
     const qb = orm.em.createQueryBuilder(BookTag2, 't');
-    qb.select(['b.*', 't.*', 'COUNT(t.id) as tags'])
+    qb.select(['b.*', 't.*', 'count(t.id) as tags'])
       .leftJoin('t.books', 'b')
-      .where('b.title = ? OR b.title = ?', ['test 123', 'lol 321'])
+      .where('b.title = ? or b.title = ?', ['test 123', 'lol 321'])
       .groupBy('b.uuid')
-      .having({ 'b.uuid': '...', 'COUNT(t.id)': { $gt: 0 } })
+      .having({ $or: [{ 'b.uuid': '...', 'count(t.id)': { $gt: 0 } }, { 'b.title': 'my title' }] })
       .limit(2, 1);
-    const sql = 'SELECT `b`.*, `t`.*, COUNT(t.id) as tags, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` FROM `book_tag2` AS `t` ' +
-      'LEFT JOIN `book2_to_book_tag2` AS `e1` ON `t`.`id` = `e1`.`book_tag2_id` ' +
-      'LEFT JOIN `book2` AS `b` ON `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
-      'WHERE (b.title = ? OR b.title = ?) ' +
-      'GROUP BY `b`.`uuid_pk` ' +
-      'HAVING `b`.`uuid_pk` = ? AND COUNT(t.id) > ? ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `b`.*, `t`.*, count(t.id) as tags, `e1`.`book_tag2_id`, `e1`.`book2_uuid_pk` from `book_tag2` as `t` ' +
+      'left join `book2_to_book_tag2` as `e1` on `t`.`id` = `e1`.`book_tag2_id` ' +
+      'left join `book2` as `b` on `e1`.`book2_uuid_pk` = `b`.`uuid_pk` ' +
+      'where (b.title = ? or b.title = ?) ' +
+      'group by `b`.`uuid_pk` ' +
+      'having ((`b`.`uuid_pk` = ? and count(t.id) > ?) or `b`.`title` = ?) ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
-    expect(qb.getParams()).toEqual(['test 123', 'lol 321', '...', 0, 2, 1]);
+    expect(qb.getParams()).toEqual(['test 123', 'lol 321', '...', 0, 'my title', 2, 1]);
   });
 
-  test('select with operator (AND)', async () => {
+  test('select with operator (and)', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
     qb.select('*').where({ $and: [
       { id: { $in: [1, 2, 7] }, },
@@ -462,19 +463,19 @@ describe('QueryBuilder', () => {
       { id: { $ne: 9 }, },
       { $not: { id: { $eq: 10 } } },
     ] });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `test2` AS `e0` ' +
-      'WHERE (`e0`.`id` IN (?, ?, ?) ' +
-      'AND `e0`.`id` NOT IN (?, ?) ' +
-      'AND `e0`.`id` > ? ' +
-      'AND `e0`.`id` < ? ' +
-      'AND `e0`.`id` >= ? ' +
-      'AND `e0`.`id` <= ? ' +
-      'AND `e0`.`id` != ? ' +
-      'AND NOT (`e0`.`id` = ?))');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0` ' +
+      'where (`e0`.`id` in (?, ?, ?) ' +
+      'and `e0`.`id` not in (?, ?) ' +
+      'and `e0`.`id` > ? ' +
+      'and `e0`.`id` < ? ' +
+      'and `e0`.`id` >= ? ' +
+      'and `e0`.`id` <= ? ' +
+      'and `e0`.`id` != ? ' +
+      'and not (`e0`.`id` = ?))');
     expect(qb.getParams()).toEqual([1, 2, 7, 3, 4, 5, 10, 7, 8, 9, 10]);
   });
 
-  test('select with operator (OR)', async () => {
+  test('select with operator (or)', async () => {
     const qb = orm.em.createQueryBuilder(Test2);
     qb.select('*').where({ $or: [
       { id: { $in: [1, 2, 7] }, },
@@ -486,15 +487,15 @@ describe('QueryBuilder', () => {
       { id: { $ne: 9 }, },
       { $not: { id: { $eq: 10 } } },
     ] });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `test2` AS `e0` ' +
-      'WHERE (`e0`.`id` IN (?, ?, ?) ' +
-      'OR `e0`.`id` NOT IN (?, ?) ' +
-      'OR `e0`.`id` > ? ' +
-      'OR `e0`.`id` < ? ' +
-      'OR `e0`.`id` >= ? ' +
-      'OR `e0`.`id` <= ? ' +
-      'OR `e0`.`id` != ? ' +
-      'OR NOT (`e0`.`id` = ?))');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0` ' +
+      'where (`e0`.`id` in (?, ?, ?) ' +
+      'or `e0`.`id` not in (?, ?) ' +
+      'or `e0`.`id` > ? ' +
+      'or `e0`.`id` < ? ' +
+      'or `e0`.`id` >= ? ' +
+      'or `e0`.`id` <= ? ' +
+      'or `e0`.`id` != ? ' +
+      'or not (`e0`.`id` = ?))');
     expect(qb.getParams()).toEqual([1, 2, 7, 3, 4, 5, 10, 7, 8, 9, 10]);
   });
 
@@ -509,56 +510,56 @@ describe('QueryBuilder', () => {
       'key6:in': [6, 7],
       'key7:nin': [8, 9],
     });
-    expect(qb.getQuery()).toEqual('SELECT `e0`.* FROM `test2` AS `e0` ' +
-      'WHERE `e0`.`key1` > ? ' +
-      'AND `e0`.`key2` < ? ' +
-      'AND `e0`.`key3` >= ? ' +
-      'AND `e0`.`key4` <= ? ' +
-      'AND `e0`.`key5` != ? ' +
-      'AND `e0`.`key6` IN (?, ?) ' +
-      'AND `e0`.`key7` NOT IN (?, ?)');
+    expect(qb.getQuery()).toEqual('select `e0`.* from `test2` as `e0` ' +
+      'where `e0`.`key1` > ? ' +
+      'and `e0`.`key2` < ? ' +
+      'and `e0`.`key3` >= ? ' +
+      'and `e0`.`key4` <= ? ' +
+      'and `e0`.`key5` != ? ' +
+      'and `e0`.`key6` in (?, ?) ' +
+      'and `e0`.`key7` not in (?, ?)');
     expect(qb.getParams()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 
   test('select count query', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.count().where({ name: 'test 123', type: PublisherType.GLOBAL });
-    expect(qb.getQuery()).toEqual('SELECT COUNT(`e0`.`id`) AS `count` FROM `publisher2` AS `e0` WHERE `e0`.`name` = ? AND `e0`.`type` = ?');
+    expect(qb.getQuery()).toEqual('select count(`e0`.`id`) as `count` from `publisher2` as `e0` where `e0`.`name` = ? and `e0`.`type` = ?');
     expect(qb.getParams()).toEqual(['test 123', PublisherType.GLOBAL]);
   });
 
   test('select count distinct query', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.count('id', true).where({ name: 'test 123', type: PublisherType.GLOBAL });
-    expect(qb.getQuery()).toEqual('SELECT COUNT(DISTINCT `e0`.`id`) AS `count` FROM `publisher2` AS `e0` WHERE `e0`.`name` = ? AND `e0`.`type` = ?');
+    expect(qb.getQuery()).toEqual('select count(distinct `e0`.`id`) as `count` from `publisher2` as `e0` where `e0`.`name` = ? and `e0`.`type` = ?');
     expect(qb.getParams()).toEqual(['test 123', PublisherType.GLOBAL]);
   });
 
   test('select count with non-standard PK field name (uuid_pk)', async () => {
     const qb = orm.em.createQueryBuilder(Book2);
     qb.count().where({ title: 'test 123' });
-    expect(qb.getQuery()).toEqual('SELECT COUNT(`e0`.`uuid_pk`) AS `count` FROM `book2` AS `e0` WHERE `e0`.`title` = ?');
+    expect(qb.getQuery()).toEqual('select count(`e0`.`uuid_pk`) as `count` from `book2` as `e0` where `e0`.`title` = ?');
     expect(qb.getParams()).toEqual(['test 123']);
   });
 
   test('select with locking', async () => {
     const qb1 = orm.em.createQueryBuilder(Test2);
     qb1.select('*').where({ title: 'test 123' }).setLockMode(LockMode.OPTIMISTIC);
-    expect(qb1.getQuery()).toEqual('SELECT `e0`.* FROM `test2` AS `e0` WHERE `e0`.`title` = ?');
+    expect(qb1.getQuery()).toEqual('select `e0`.* from `test2` as `e0` where `e0`.`title` = ?');
 
-    await orm.em.beginTransaction();
-    const qb2 = orm.em.createQueryBuilder(Book2);
-    qb2.select('*').where({ title: 'test 123' }).setLockMode(LockMode.NONE);
-    expect(qb2.getQuery()).toEqual('SELECT `e0`.* FROM `book2` AS `e0` WHERE `e0`.`title` = ?');
+    await orm.em.transactional(async em => {
+      const qb2 = em.createQueryBuilder(Book2);
+      qb2.select('*').where({ title: 'test 123' }).setLockMode(LockMode.NONE);
+      expect(qb2.getQuery()).toEqual('select `e0`.* from `book2` as `e0` where `e0`.`title` = ?');
 
-    const qb3 = orm.em.createQueryBuilder(Book2);
-    qb3.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_READ);
-    expect(qb3.getQuery()).toEqual('SELECT `e0`.* FROM `book2` AS `e0` WHERE `e0`.`title` = ? LOCK IN SHARE MODE');
+      const qb3 = em.createQueryBuilder(Book2);
+      qb3.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_READ);
+      expect(qb3.getQuery()).toEqual('select `e0`.* from `book2` as `e0` where `e0`.`title` = ? lock in share mode');
 
-    const qb4 = orm.em.createQueryBuilder(Book2);
-    qb4.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_WRITE);
-    expect(qb4.getQuery()).toEqual('SELECT `e0`.* FROM `book2` AS `e0` WHERE `e0`.`title` = ? FOR UPDATE');
-    await orm.em.commit();
+      const qb4 = em.createQueryBuilder(Book2);
+      qb4.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_WRITE);
+      expect(qb4.getQuery()).toEqual('select `e0`.* from `book2` as `e0` where `e0`.`title` = ? for update');
+    });
   });
 
   test('pessimistic locking requires active transaction', async () => {
@@ -573,24 +574,24 @@ describe('QueryBuilder', () => {
   test('insert query', async () => {
     const qb1 = orm.em.createQueryBuilder(Publisher2);
     qb1.insert({ name: 'test 123', type: PublisherType.GLOBAL });
-    expect(qb1.getQuery()).toEqual('INSERT INTO `publisher2` (`name`, `type`) VALUES (?, ?)');
+    expect(qb1.getQuery()).toEqual('insert into `publisher2` (`name`, `type`) values (?, ?)');
     expect(qb1.getParams()).toEqual(['test 123', PublisherType.GLOBAL]);
 
     const qb2 = orm.em.createQueryBuilder(Author2);
     qb2.insert({ name: 'test 123', favouriteBook: 2359, termsAccepted: true });
-    expect(qb2.getQuery()).toEqual('INSERT INTO `author2` (`name`, `favourite_book_uuid_pk`, `terms_accepted`) VALUES (?, ?, ?)');
-    expect(qb2.getParams()).toEqual(['test 123', 2359, true]);
+    expect(qb2.getQuery()).toEqual('insert into `author2` (`favourite_book_uuid_pk`, `name`, `terms_accepted`) values (?, ?, ?)');
+    expect(qb2.getParams()).toEqual([2359, 'test 123', true]);
 
     const qb3 = orm.em.createQueryBuilder(BookTag2);
     qb3.insert({ books: 123 });
-    expect(qb3.getQuery()).toEqual('INSERT INTO `book_tag2` (`books`) VALUES (?)');
+    expect(qb3.getQuery()).toEqual('insert into `book_tag2` (`books`) values (?)');
     expect(qb3.getParams()).toEqual([123]);
   });
 
   test('update query', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.update({ name: 'test 123', type: PublisherType.GLOBAL }).where({ id: 123, type: PublisherType.LOCAL });
-    expect(qb.getQuery()).toEqual('UPDATE `publisher2` SET `name` = ?, `type` = ? WHERE `id` = ? AND `type` = ?');
+    expect(qb.getQuery()).toEqual('update `publisher2` set `name` = ?, `type` = ? where `id` = ? and `type` = ?');
     expect(qb.getParams()).toEqual(['test 123', PublisherType.GLOBAL, 123, PublisherType.LOCAL]);
   });
 
@@ -599,14 +600,14 @@ describe('QueryBuilder', () => {
     const test = Test2.create('test');
     test.id = 321;
     qb.update({ name: 'test 123', test }).where({ id: 123, type: PublisherType.LOCAL });
-    expect(qb.getQuery()).toEqual('UPDATE `publisher2` SET `name` = ?, `test` = ? WHERE `id` = ? AND `type` = ?');
+    expect(qb.getQuery()).toEqual('update `publisher2` set `name` = ?, `test` = ? where `id` = ? and `type` = ?');
     expect(qb.getParams()).toEqual(['test 123', 321, 123, PublisherType.LOCAL]);
   });
 
   test('delete query', async () => {
     const qb = orm.em.createQueryBuilder(Publisher2);
     qb.delete({ name: 'test 123', type: PublisherType.GLOBAL });
-    expect(qb.getQuery()).toEqual('DELETE FROM `publisher2` WHERE `name` = ? AND `type` = ?');
+    expect(qb.getQuery()).toEqual('delete from `publisher2` where `name` = ? and `type` = ?');
     expect(qb.getParams()).toEqual(['test 123', PublisherType.GLOBAL]);
   });
 
@@ -636,27 +637,26 @@ describe('QueryBuilder', () => {
     expect(clone['_offset']).toBe(qb['_offset']);
 
     clone.orWhere({ 'p.name': 'or this name' }).orderBy({ 'p.name': QueryOrder.ASC }).limit(10, 5);
-    clone.limit(10, 5);
 
-    const sql = 'SELECT `p`.*, `b`.*, `a`.*, `t`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` FROM `publisher2` AS `p` ' +
-      'LEFT JOIN `book2` AS `b` ON `p`.`id` = `b`.`publisher_id` ' +
-      'JOIN `author2` AS `a` ON `b`.`author_id` = `a`.`id` ' +
-      'JOIN `book2_to_book_tag2` AS `e1` ON `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
-      'JOIN `book_tag2` AS `t` ON `e1`.`book_tag2_id` = `t`.`id` ' +
-      'WHERE `p`.`name` = ? AND `b`.`title` LIKE ? ' +
-      'ORDER BY `b`.`title` DESC ' +
-      'LIMIT ? OFFSET ?';
+    const sql = 'select `p`.*, `b`.*, `a`.*, `t`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` from `publisher2` as `p` ' +
+      'left join `book2` as `b` on `p`.`id` = `b`.`publisher_id` ' +
+      'inner join `author2` as `a` on `b`.`author_id` = `a`.`id` ' +
+      'inner join `book2_to_book_tag2` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
+      'inner join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` ' +
+      'where `p`.`name` = ? and `b`.`title` like ? ' +
+      'order by `b`.`title` desc ' +
+      'limit ? offset ?';
     expect(qb.getQuery()).toEqual(sql);
     expect(qb.getParams()).toEqual(['test 123', '%3', 2, 1]);
 
-    const sql2 = 'SELECT `p`.*, `b`.*, `a`.*, `t`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` FROM `publisher2` AS `p` ' +
-      'LEFT JOIN `book2` AS `b` ON `p`.`id` = `b`.`publisher_id` ' +
-      'JOIN `author2` AS `a` ON `b`.`author_id` = `a`.`id` ' +
-      'JOIN `book2_to_book_tag2` AS `e1` ON `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
-      'JOIN `book_tag2` AS `t` ON `e1`.`book_tag2_id` = `t`.`id` ' +
-      'WHERE ((`p`.`name` = ? AND `b`.`title` LIKE ?) OR `p`.`name` = ?) ' +
-      'ORDER BY `p`.`name` ASC ' +
-      'LIMIT ? OFFSET ?';
+    const sql2 = 'select `p`.*, `b`.*, `a`.*, `t`.*, `e1`.`book2_uuid_pk`, `e1`.`book_tag2_id` from `publisher2` as `p` ' +
+      'left join `book2` as `b` on `p`.`id` = `b`.`publisher_id` ' +
+      'inner join `author2` as `a` on `b`.`author_id` = `a`.`id` ' +
+      'inner join `book2_to_book_tag2` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
+      'inner join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` ' +
+      'where ((`p`.`name` = ? and `b`.`title` like ?) or `p`.`name` = ?) ' +
+      'order by `p`.`name` asc ' +
+      'limit ? offset ?';
     expect(clone.getQuery()).toEqual(sql2);
     expect(clone.getParams()).toEqual(['test 123', '%3', 'or this name', 10, 5]);
   });

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -1,12 +1,6 @@
 import { SchemaHelper } from '../lib/schema';
 
-class SchemaHelperTest extends SchemaHelper {
-
-  supportsSequences(): boolean {
-    return true;
-  }
-
-}
+class SchemaHelperTest extends SchemaHelper { }
 
 /**
  * @class SchemaHelperTest
@@ -17,17 +11,7 @@ describe('SchemaHelper', () => {
     const helper = new SchemaHelperTest();
     expect(helper.getSchemaBeginning()).toBe('');
     expect(helper.getSchemaEnd()).toBe('');
-    expect(helper.supportsSequences()).toBe(true);
     expect(helper.getTypeDefinition({ type: 'test' } as any)).toBe('test');
-
-    const meta = {
-      collection: 'test',
-      primaryKey: 'pk',
-      properties: {
-        pk: { name: 'pk', type: 'number' },
-      },
-    };
-    expect(helper.dropTable(meta as any)).toBe('DROP TABLE IF EXISTS "test";\nDROP SEQUENCE IF EXISTS "test_seq";\n');
   });
 
 });

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -1,395 +1,176 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-schema-dump 1`] = `
-"SET NAMES utf8;
-SET FOREIGN_KEY_CHECKS=0;
+"set names utf8;
+set foreign_key_checks = 0;
 
+drop table if exists \`author2\`;
+drop table if exists \`book2\`;
+drop table if exists \`book_tag2\`;
+drop table if exists \`publisher2\`;
+drop table if exists \`test2\`;
+drop table if exists \`foo_bar2\`;
+drop table if exists \`foo_baz2\`;
+drop table if exists \`book2_to_book_tag2\`;
+drop table if exists \`publisher2_to_test2\`;
 
-DROP TABLE IF EXISTS \`author2\`;
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null, \`terms_accepted\` tinyint(1) not null default 0, \`identities\` json null, \`born\` datetime null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table \`author2\` add unique \`author2_email_unique\`(\`email\`);
+alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);
+alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favourite_author_id\`);
 
-CREATE TABLE \`author2\` (
-  \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  \`created_at\` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  \`updated_at\` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  \`name\` varchar(255) NOT NULL,
-  \`email\` varchar(255) UNIQUE NOT NULL,
-  \`age\` int(11) DEFAULT NULL,
-  \`terms_accepted\` tinyint(1) NOT NULL DEFAULT 0,
-  \`identities\` json DEFAULT NULL,
-  \`born\` datetime DEFAULT NULL,
-  \`favourite_book_uuid_pk\` varchar(36) DEFAULT NULL,
-  \`favourite_author_id\` int(11) unsigned DEFAULT NULL,
-  PRIMARY KEY (\`id\`),
-  KEY \`favourite_book_uuid_pk\` (\`favourite_book_uuid_pk\`),
-  KEY \`favourite_author_id\` (\`favourite_author_id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null, \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned null, \`publisher_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
+alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
+alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
 
+create table \`book_tag2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8 engine = InnoDB;
 
-DROP TABLE IF EXISTS \`book2\`;
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` varchar(10) not null) default character set utf8 engine = InnoDB;
 
-CREATE TABLE \`book2\` (
-  \`uuid_pk\` varchar(36) NOT NULL,
-  \`created_at\` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  \`title\` varchar(255) DEFAULT NULL,
-  \`perex\` text DEFAULT NULL,
-  \`price\` float DEFAULT NULL,
-  \`double\` double DEFAULT NULL,
-  \`meta\` json DEFAULT NULL,
-  \`author_id\` int(11) unsigned DEFAULT NULL,
-  \`publisher_id\` int(11) unsigned DEFAULT NULL,
-  PRIMARY KEY (\`uuid_pk\`),
-  KEY \`author_id\` (\`author_id\`),
-  KEY \`publisher_id\` (\`publisher_id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`version\` int(11) not null default 1) default character set utf8 engine = InnoDB;
+alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
+alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
 
-DROP TABLE IF EXISTS \`book_tag2\`;
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8 engine = InnoDB;
 
-CREATE TABLE \`book_tag2\` (
-  \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  \`name\` varchar(50) NOT NULL,
-  PRIMARY KEY (\`id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+create table \`book2_to_book_tag2\` (\`id\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book_tag2_id_index\`(\`book_tag2_id\`);
 
+create table \`publisher2_to_test2\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table \`publisher2_to_test2\` add index \`publisher2_to_test2_publisher2_id_index\`(\`publisher2_id\`);
+alter table \`publisher2_to_test2\` add index \`publisher2_to_test2_test2_id_index\`(\`test2_id\`);
 
-DROP TABLE IF EXISTS \`publisher2\`;
+alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete set null;
+alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
 
-CREATE TABLE \`publisher2\` (
-  \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  \`name\` varchar(255) NOT NULL,
-  \`type\` varchar(10) NOT NULL,
-  PRIMARY KEY (\`id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on delete set null;
+alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on delete set null;
 
+alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
 
-DROP TABLE IF EXISTS \`test2\`;
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
 
-CREATE TABLE \`test2\` (
-  \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  \`name\` varchar(255) DEFAULT NULL,
-  \`book_uuid_pk\` varchar(36) UNIQUE DEFAULT NULL,
-  \`version\` int(11) NOT NULL DEFAULT 1,
-  PRIMARY KEY (\`id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+alter table \`book2_to_book_tag2\` add constraint \`book2_to_book_tag2_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
+alter table \`book2_to_book_tag2\` add constraint \`book2_to_book_tag2_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
 
+alter table \`publisher2_to_test2\` add constraint \`publisher2_to_test2_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_to_test2\` add constraint \`publisher2_to_test2_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
 
-DROP TABLE IF EXISTS \`foo_bar2\`;
-
-CREATE TABLE \`foo_bar2\` (
-  \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  \`name\` varchar(255) NOT NULL,
-  \`baz_id\` int(11) unsigned UNIQUE DEFAULT NULL,
-  \`foo_bar_id\` int(11) unsigned UNIQUE DEFAULT NULL,
-  \`version\` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  PRIMARY KEY (\`id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-DROP TABLE IF EXISTS \`foo_baz2\`;
-
-CREATE TABLE \`foo_baz2\` (
-  \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  \`name\` varchar(255) NOT NULL,
-  PRIMARY KEY (\`id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-DROP TABLE IF EXISTS \`book2_to_book_tag2\`;
-
-CREATE TABLE \`book2_to_book_tag2\` (
-  \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  \`book2_uuid_pk\` varchar(36) NOT NULL,
-  \`book_tag2_id\` int(11) unsigned NOT NULL,
-  PRIMARY KEY (\`id\`),
-  KEY \`book2_uuid_pk\` (\`book2_uuid_pk\`),
-  KEY \`book_tag2_id\` (\`book_tag2_id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-DROP TABLE IF EXISTS \`publisher2_to_test2\`;
-
-CREATE TABLE \`publisher2_to_test2\` (
-  \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  \`publisher2_id\` int(11) unsigned NOT NULL,
-  \`test2_id\` int(11) unsigned NOT NULL,
-  PRIMARY KEY (\`id\`),
-  KEY \`publisher2_id\` (\`publisher2_id\`),
-  KEY \`test2_id\` (\`test2_id\`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-ALTER TABLE \`author2\`
-  ADD CONSTRAINT \`author2_ibfk_1\` FOREIGN KEY (\`favourite_book_uuid_pk\`) REFERENCES \`book2\` (\`uuid_pk\`) ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT \`author2_ibfk_2\` FOREIGN KEY (\`favourite_author_id\`) REFERENCES \`author2\` (\`id\`) ON DELETE SET NULL ON UPDATE CASCADE;
-
-
-ALTER TABLE \`book2\`
-  ADD CONSTRAINT \`book2_ibfk_1\` FOREIGN KEY (\`author_id\`) REFERENCES \`author2\` (\`id\`) ON DELETE SET NULL,
-  ADD CONSTRAINT \`book2_ibfk_2\` FOREIGN KEY (\`publisher_id\`) REFERENCES \`publisher2\` (\`id\`) ON DELETE SET NULL;
-
-
-ALTER TABLE \`test2\`
-  ADD CONSTRAINT \`test2_ibfk_1\` FOREIGN KEY (\`book_uuid_pk\`) REFERENCES \`book2\` (\`uuid_pk\`) ON DELETE SET NULL;
-
-
-ALTER TABLE \`foo_bar2\`
-  ADD CONSTRAINT \`foo_bar2_ibfk_1\` FOREIGN KEY (\`baz_id\`) REFERENCES \`foo_baz2\` (\`id\`) ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT \`foo_bar2_ibfk_2\` FOREIGN KEY (\`foo_bar_id\`) REFERENCES \`foo_bar2\` (\`id\`) ON DELETE SET NULL ON UPDATE CASCADE;
-
-
-ALTER TABLE \`book2_to_book_tag2\`
-  ADD CONSTRAINT \`book2_to_book_tag2_ibfk_1\` FOREIGN KEY (\`book2_uuid_pk\`) REFERENCES \`book2\` (\`uuid_pk\`) ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT \`book2_to_book_tag2_ibfk_2\` FOREIGN KEY (\`book_tag2_id\`) REFERENCES \`book_tag2\` (\`id\`) ON DELETE CASCADE ON UPDATE CASCADE;
-
-
-ALTER TABLE \`publisher2_to_test2\`
-  ADD CONSTRAINT \`publisher2_to_test2_ibfk_1\` FOREIGN KEY (\`publisher2_id\`) REFERENCES \`publisher2\` (\`id\`) ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT \`publisher2_to_test2_ibfk_2\` FOREIGN KEY (\`test2_id\`) REFERENCES \`test2\` (\`id\`) ON DELETE CASCADE ON UPDATE CASCADE;
-
-
-SET FOREIGN_KEY_CHECKS=1;
+set foreign_key_checks = 1;
 "
 `;
 
 exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-schema-dump 1`] = `
-"SET NAMES 'utf8';
-SET session_replication_role = 'replica';
+"set names 'utf8';
+set session_replication_role = 'replica';
 
+drop table if exists \\"author2\\";
+drop table if exists \\"book2\\";
+drop table if exists \\"book_tag2\\";
+drop table if exists \\"publisher2\\";
+drop table if exists \\"test2\\";
+drop table if exists \\"foo_bar2\\";
+drop table if exists \\"foo_baz2\\";
+drop table if exists \\"book2_to_book_tag2\\";
+drop table if exists \\"publisher2_to_test2\\";
 
-DROP TABLE IF EXISTS \\"author2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"author2_seq\\";
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"updated_at\\" timestamp(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int null, \\"terms_accepted\\" boolean not null default 0, \\"identities\\" json null, \\"born\\" timestamp null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int null);
+alter table \\"author2\\" add constraint \\"author2_email_unique\\" unique (\\"email\\");
 
-CREATE SEQUENCE \\"author2_seq\\";
-CREATE TABLE \\"author2\\" (
-  \\"id\\" int check (\\"id\\" > 0) NOT NULL DEFAULT NEXTVAL('author2_seq'),
-  \\"created_at\\" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  \\"updated_at\\" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  \\"name\\" varchar(255) NOT NULL,
-  \\"email\\" varchar(255) UNIQUE NOT NULL,
-  \\"age\\" int DEFAULT NULL,
-  \\"terms_accepted\\" boolean NOT NULL DEFAULT 0,
-  \\"identities\\" json DEFAULT NULL,
-  \\"born\\" timestamp DEFAULT NULL,
-  \\"favourite_book_uuid_pk\\" varchar(36) DEFAULT NULL,
-  \\"favourite_author_id\\" int check (\\"favourite_author_id\\" > 0) DEFAULT NULL,
-  PRIMARY KEY (\\"id\\")
-);
+create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double precision null, \\"meta\\" json null, \\"author_id\\" int null, \\"publisher_id\\" int null);
+alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
+create table \\"book_tag2\\" (\\"id\\" serial primary key, \\"name\\" varchar(50) not null);
 
-DROP TABLE IF EXISTS \\"book2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"book2_seq\\";
+create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" varchar(10) not null);
 
-CREATE TABLE \\"book2\\" (
-  \\"uuid_pk\\" varchar(36) NOT NULL,
-  \\"created_at\\" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  \\"title\\" varchar(255) DEFAULT NULL,
-  \\"perex\\" text DEFAULT NULL,
-  \\"price\\" float DEFAULT NULL,
-  \\"double\\" double precision DEFAULT NULL,
-  \\"meta\\" json DEFAULT NULL,
-  \\"author_id\\" int check (\\"author_id\\" > 0) DEFAULT NULL,
-  \\"publisher_id\\" int check (\\"publisher_id\\" > 0) DEFAULT NULL,
-  PRIMARY KEY (\\"uuid_pk\\")
-);
+create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int not null default 1);
+alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int null, \\"foo_bar_id\\" int null, \\"version\\" timestamp(3) not null default current_timestamp(3));
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
-DROP TABLE IF EXISTS \\"book_tag2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"book_tag2_seq\\";
+create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null);
 
-CREATE SEQUENCE \\"book_tag2_seq\\";
-CREATE TABLE \\"book_tag2\\" (
-  \\"id\\" int check (\\"id\\" > 0) NOT NULL DEFAULT NEXTVAL('book_tag2_seq'),
-  \\"name\\" varchar(50) NOT NULL,
-  PRIMARY KEY (\\"id\\")
-);
+create table \\"book2_to_book_tag2\\" (\\"id\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int not null);
 
+create table \\"publisher2_to_test2\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int not null, \\"test2_id\\" int not null);
 
-DROP TABLE IF EXISTS \\"publisher2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"publisher2_seq\\";
+alter table \\"author2\\" add constraint \\"author2_favourite_book_uuid_pk_foreign\\" foreign key (\\"favourite_book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete set null;
+alter table \\"author2\\" add constraint \\"author2_favourite_author_id_foreign\\" foreign key (\\"favourite_author_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete set null;
 
-CREATE SEQUENCE \\"publisher2_seq\\";
-CREATE TABLE \\"publisher2\\" (
-  \\"id\\" int check (\\"id\\" > 0) NOT NULL DEFAULT NEXTVAL('publisher2_seq'),
-  \\"name\\" varchar(255) NOT NULL,
-  \\"type\\" varchar(10) NOT NULL,
-  PRIMARY KEY (\\"id\\")
-);
+alter table \\"book2\\" add constraint \\"book2_author_id_foreign\\" foreign key (\\"author_id\\") references \\"author2\\" (\\"id\\") on delete set null;
+alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on delete set null;
 
+alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
 
-DROP TABLE IF EXISTS \\"test2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"test2_seq\\";
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade on delete set null;
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" foreign key (\\"foo_bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade on delete set null;
 
-CREATE SEQUENCE \\"test2_seq\\";
-CREATE TABLE \\"test2\\" (
-  \\"id\\" int check (\\"id\\" > 0) NOT NULL DEFAULT NEXTVAL('test2_seq'),
-  \\"name\\" varchar(255) DEFAULT NULL,
-  \\"book_uuid_pk\\" varchar(36) UNIQUE DEFAULT NULL,
-  \\"version\\" int NOT NULL DEFAULT 1,
-  PRIMARY KEY (\\"id\\")
-);
+alter table \\"book2_to_book_tag2\\" add constraint \\"book2_to_book_tag2_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
+alter table \\"book2_to_book_tag2\\" add constraint \\"book2_to_book_tag2_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
 
+alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
 
-DROP TABLE IF EXISTS \\"foo_bar2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"foo_bar2_seq\\";
-
-CREATE SEQUENCE \\"foo_bar2_seq\\";
-CREATE TABLE \\"foo_bar2\\" (
-  \\"id\\" int check (\\"id\\" > 0) NOT NULL DEFAULT NEXTVAL('foo_bar2_seq'),
-  \\"name\\" varchar(255) NOT NULL,
-  \\"baz_id\\" int check (\\"baz_id\\" > 0) UNIQUE DEFAULT NULL,
-  \\"foo_bar_id\\" int check (\\"foo_bar_id\\" > 0) UNIQUE DEFAULT NULL,
-  \\"version\\" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  PRIMARY KEY (\\"id\\")
-);
-
-
-DROP TABLE IF EXISTS \\"foo_baz2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"foo_baz2_seq\\";
-
-CREATE SEQUENCE \\"foo_baz2_seq\\";
-CREATE TABLE \\"foo_baz2\\" (
-  \\"id\\" int check (\\"id\\" > 0) NOT NULL DEFAULT NEXTVAL('foo_baz2_seq'),
-  \\"name\\" varchar(255) NOT NULL,
-  PRIMARY KEY (\\"id\\")
-);
-
-
-DROP TABLE IF EXISTS \\"book2_to_book_tag2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"book2_to_book_tag2_seq\\";
-
-CREATE SEQUENCE \\"book2_to_book_tag2_seq\\";
-CREATE TABLE \\"book2_to_book_tag2\\" (
-  \\"id\\" int check (\\"id\\" > 0) NOT NULL DEFAULT NEXTVAL('book2_to_book_tag2_seq'),
-  \\"book2_uuid_pk\\" varchar(36) NOT NULL,
-  \\"book_tag2_id\\" int check (\\"book_tag2_id\\" > 0) NOT NULL,
-  PRIMARY KEY (\\"id\\")
-);
-
-
-DROP TABLE IF EXISTS \\"publisher2_to_test2\\" CASCADE;
-DROP SEQUENCE IF EXISTS \\"publisher2_to_test2_seq\\";
-
-CREATE SEQUENCE \\"publisher2_to_test2_seq\\";
-CREATE TABLE \\"publisher2_to_test2\\" (
-  \\"id\\" int check (\\"id\\" > 0) NOT NULL DEFAULT NEXTVAL('publisher2_to_test2_seq'),
-  \\"publisher2_id\\" int check (\\"publisher2_id\\" > 0) NOT NULL,
-  \\"test2_id\\" int check (\\"test2_id\\" > 0) NOT NULL,
-  PRIMARY KEY (\\"id\\")
-);
-
-
-ALTER TABLE \\"author2\\"
-  ADD CONSTRAINT \\"author2_ibfk_1\\" FOREIGN KEY (\\"favourite_book_uuid_pk\\") REFERENCES \\"book2\\" (\\"uuid_pk\\") ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT \\"author2_ibfk_2\\" FOREIGN KEY (\\"favourite_author_id\\") REFERENCES \\"author2\\" (\\"id\\") ON DELETE SET NULL ON UPDATE CASCADE;
-
-
-ALTER TABLE \\"book2\\"
-  ADD CONSTRAINT \\"book2_ibfk_1\\" FOREIGN KEY (\\"author_id\\") REFERENCES \\"author2\\" (\\"id\\") ON DELETE SET NULL,
-  ADD CONSTRAINT \\"book2_ibfk_2\\" FOREIGN KEY (\\"publisher_id\\") REFERENCES \\"publisher2\\" (\\"id\\") ON DELETE SET NULL;
-
-
-ALTER TABLE \\"test2\\"
-  ADD CONSTRAINT \\"test2_ibfk_1\\" FOREIGN KEY (\\"book_uuid_pk\\") REFERENCES \\"book2\\" (\\"uuid_pk\\") ON DELETE SET NULL;
-
-
-ALTER TABLE \\"foo_bar2\\"
-  ADD CONSTRAINT \\"foo_bar2_ibfk_1\\" FOREIGN KEY (\\"baz_id\\") REFERENCES \\"foo_baz2\\" (\\"id\\") ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT \\"foo_bar2_ibfk_2\\" FOREIGN KEY (\\"foo_bar_id\\") REFERENCES \\"foo_bar2\\" (\\"id\\") ON DELETE SET NULL ON UPDATE CASCADE;
-
-
-ALTER TABLE \\"book2_to_book_tag2\\"
-  ADD CONSTRAINT \\"book2_to_book_tag2_ibfk_1\\" FOREIGN KEY (\\"book2_uuid_pk\\") REFERENCES \\"book2\\" (\\"uuid_pk\\") ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT \\"book2_to_book_tag2_ibfk_2\\" FOREIGN KEY (\\"book_tag2_id\\") REFERENCES \\"book_tag2\\" (\\"id\\") ON DELETE CASCADE ON UPDATE CASCADE;
-
-
-ALTER TABLE \\"publisher2_to_test2\\"
-  ADD CONSTRAINT \\"publisher2_to_test2_ibfk_1\\" FOREIGN KEY (\\"publisher2_id\\") REFERENCES \\"publisher2\\" (\\"id\\") ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT \\"publisher2_to_test2_ibfk_2\\" FOREIGN KEY (\\"test2_id\\") REFERENCES \\"test2\\" (\\"id\\") ON DELETE CASCADE ON UPDATE CASCADE;
-
-
-SET session_replication_role = 'origin';
+set session_replication_role = 'origin';
 "
 `;
 
 exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-schema-dump 1`] = `
-"PRAGMA foreign_keys=OFF;
+"pragma foreign_keys = off;
 
+drop table if exists \`author3\`;
+drop table if exists \`book3\`;
+drop table if exists \`book_tag3\`;
+drop table if exists \`publisher3\`;
+drop table if exists \`test3\`;
+drop table if exists \`book3_to_book_tag3\`;
+drop table if exists \`publisher3_to_test3\`;
 
-DROP TABLE IF EXISTS \\"author3\\";
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` text null, \`updated_at\` text null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` text null);
+create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
-CREATE TABLE \\"author3\\" (
-  \\"id\\" INTEGER PRIMARY KEY AUTOINCREMENT,
-  \\"created_at\\" TEXT DEFAULT NULL,
-  \\"updated_at\\" TEXT DEFAULT NULL,
-  \\"name\\" TEXT NOT NULL,
-  \\"email\\" TEXT UNIQUE NOT NULL,
-  \\"age\\" INTEGER DEFAULT NULL,
-  \\"terms_accepted\\" INTEGER NOT NULL DEFAULT 0,
-  \\"identities\\" TEXT DEFAULT NULL,
-  \\"born\\" TEXT DEFAULT NULL
-);
+create table \`book3\` (\`id\` integer not null primary key autoincrement, \`title\` text not null);
 
+create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`version\` text not null default current_timestamp);
 
-DROP TABLE IF EXISTS \\"book3\\";
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`type\` text not null);
 
-CREATE TABLE \\"book3\\" (
-  \\"id\\" INTEGER PRIMARY KEY AUTOINCREMENT,
-  \\"title\\" TEXT NOT NULL
-);
+create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` text null, \`version\` integer not null default 1);
 
+create table \`book3_to_book_tag3\` (\`id\` integer not null primary key autoincrement);
 
-DROP TABLE IF EXISTS \\"book_tag3\\";
+create table \`publisher3_to_test3\` (\`id\` integer not null primary key autoincrement);
 
-CREATE TABLE \\"book_tag3\\" (
-  \\"id\\" INTEGER PRIMARY KEY AUTOINCREMENT,
-  \\"name\\" TEXT NOT NULL,
-  \\"version\\" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
+alter table \`author3\` add column \`favourite_book_id\` integer null;
+create index \`author3_favourite_book_id_index\` on \`author3\` (\`favourite_book_id\`);
 
+alter table \`book3\` add column \`author_id\` integer null;
+alter table \`book3\` add column \`publisher_id\` integer null;
+create index \`book3_author_id_index\` on \`book3\` (\`author_id\`);
+create index \`book3_publisher_id_index\` on \`book3\` (\`publisher_id\`);
 
-DROP TABLE IF EXISTS \\"publisher3\\";
+alter table \`book3_to_book_tag3\` add column \`book3_id\` integer null;
+alter table \`book3_to_book_tag3\` add column \`book_tag3_id\` integer null;
+create index \`book3_to_book_tag3_book3_id_index\` on \`book3_to_book_tag3\` (\`book3_id\`);
+create index \`book3_to_book_tag3_book_tag3_id_index\` on \`book3_to_book_tag3\` (\`book_tag3_id\`);
 
-CREATE TABLE \\"publisher3\\" (
-  \\"id\\" INTEGER PRIMARY KEY AUTOINCREMENT,
-  \\"name\\" TEXT NOT NULL,
-  \\"type\\" TEXT NOT NULL
-);
+alter table \`publisher3_to_test3\` add column \`publisher3_id\` integer null;
+alter table \`publisher3_to_test3\` add column \`test3_id\` integer null;
+create index \`publisher3_to_test3_publisher3_id_index\` on \`publisher3_to_test3\` (\`publisher3_id\`);
+create index \`publisher3_to_test3_test3_id_index\` on \`publisher3_to_test3\` (\`test3_id\`);
 
-
-DROP TABLE IF EXISTS \\"test3\\";
-
-CREATE TABLE \\"test3\\" (
-  \\"id\\" INTEGER PRIMARY KEY AUTOINCREMENT,
-  \\"name\\" TEXT DEFAULT NULL,
-  \\"version\\" INTEGER NOT NULL DEFAULT 1
-);
-
-
-DROP TABLE IF EXISTS \\"book3_to_book_tag3\\";
-
-CREATE TABLE \\"book3_to_book_tag3\\" (
-  \\"id\\" INTEGER PRIMARY KEY AUTOINCREMENT
-);
-
-
-DROP TABLE IF EXISTS \\"publisher3_to_test3\\";
-
-CREATE TABLE \\"publisher3_to_test3\\" (
-  \\"id\\" INTEGER PRIMARY KEY AUTOINCREMENT
-);
-
-
-ALTER TABLE \\"author3\\" ADD \\"favourite_book_id\\" INTEGER DEFAULT NULL REFERENCES \\"book3\\" (\\"id\\") ON DELETE SET NULL ON UPDATE CASCADE;
-
-ALTER TABLE \\"book3\\" ADD \\"author_id\\" INTEGER DEFAULT NULL REFERENCES \\"author3\\" (\\"id\\") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE \\"book3\\" ADD \\"publisher_id\\" INTEGER DEFAULT NULL REFERENCES \\"publisher3\\" (\\"id\\") ON DELETE SET NULL ON UPDATE CASCADE;
-
-ALTER TABLE \\"book3_to_book_tag3\\" ADD \\"book3_id\\" INTEGER DEFAULT NULL REFERENCES \\"book3\\" (\\"id\\") ON DELETE CASCADE ON UPDATE CASCADE;
-ALTER TABLE \\"book3_to_book_tag3\\" ADD \\"book_tag3_id\\" INTEGER DEFAULT NULL REFERENCES \\"book_tag3\\" (\\"id\\") ON DELETE CASCADE ON UPDATE CASCADE;
-
-ALTER TABLE \\"publisher3_to_test3\\" ADD \\"publisher3_id\\" INTEGER DEFAULT NULL REFERENCES \\"publisher3\\" (\\"id\\") ON DELETE CASCADE ON UPDATE CASCADE;
-ALTER TABLE \\"publisher3_to_test3\\" ADD \\"test3_id\\" INTEGER DEFAULT NULL REFERENCES \\"test3\\" (\\"id\\") ON DELETE CASCADE ON UPDATE CASCADE;
-
-PRAGMA foreign_keys=ON;
+pragma foreign_keys = on;
 "
 `;

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -1,6 +1,6 @@
 import { EntityManager, JavaScriptMetadataProvider, MikroORM } from '../lib';
 import { Author, Book, BookTag, Publisher, Test } from './entities';
-import { Author2, Book2, BookTag2, FooBaz2, Publisher2, Test2, FooBar2 } from './entities-sql';
+import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2 } from './entities-sql';
 import { SqliteDriver } from '../lib/drivers/SqliteDriver';
 import { MySqlConnection } from '../lib/connections/MySqlConnection';
 import { SqliteConnection } from '../lib/connections/SqliteConnection';

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -12,10 +12,10 @@ export class Author2 extends BaseEntity2 {
   static beforeDestroyCalled = 0;
   static afterDestroyCalled = 0;
 
-  @Property({ length: 3, default: 'CURRENT_TIMESTAMP(3)' })
+  @Property({ length: 3, default: 'current_timestamp(3)' })
   createdAt = new Date();
 
-  @Property({ onUpdate: () => new Date(), length: 3, default: 'CURRENT_TIMESTAMP(3)' })
+  @Property({ onUpdate: () => new Date(), length: 3, default: 'current_timestamp(3)' })
   updatedAt = new Date();
 
   @Property()

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -11,7 +11,7 @@ export class Book2 {
   @PrimaryKey({ fieldName: 'uuid_pk', length: 36 })
   uuid = v4();
 
-  @Property({ default: 'CURRENT_TIMESTAMP(3)', length: 3 })
+  @Property({ default: 'current_timestamp(3)', length: 3 })
   createdAt = new Date();
 
   @Property({ nullable: true })

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,6 +958,11 @@ array-differ@^3.0.0:
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
   integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
 
+array-each@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
+  integrity sha1-p5SvDAWrF1KEbudTofIRoFugxE8=
+
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
@@ -972,6 +977,11 @@ array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
+
+array-slice@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-1.1.0.tgz#e368ea15f89bc7069f7ffb89aec3a6c7d4ac22d4"
+  integrity sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -1596,6 +1606,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+colorette@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.0.8.tgz#421ff11c80b7414027ebed922396bc1833d1903c"
+  integrity sha512-X6Ck90ReaF+EfKdVGB7vdIQ3dr651BbIrBwY5YBKg13fjH+940sTtp7/Pkx33C6ntYfQcRumOs/aUQhaRPpbTQ==
+
 colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
@@ -1897,6 +1912,13 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@4.1.1, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1908,13 +1930,6 @@ debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -2036,6 +2051,11 @@ deprecation@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+detect-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
+  integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
 detect-indent@~5.0.0:
   version "5.0.0"
@@ -2333,6 +2353,13 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 expect@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.8.0.tgz#471f8ec256b7b6129ca2524b2a62f030df38718d"
@@ -2360,7 +2387,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -2509,6 +2536,32 @@ find-versions@^3.0.0:
     array-uniq "^2.1.0"
     semver-regex "^2.0.0"
 
+findup-sync@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
+  integrity sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^4.0.0"
+    micromatch "^3.0.4"
+    resolve-dir "^1.0.1"
+
+fined@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fined/-/fined-1.2.0.tgz#d00beccf1aa2b475d16d423b0238b713a2c4a37b"
+  integrity sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==
+  dependencies:
+    expand-tilde "^2.0.2"
+    is-plain-object "^2.0.3"
+    object.defaults "^1.1.0"
+    object.pick "^1.2.0"
+    parse-filepath "^1.0.1"
+
+flagged-respawn@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
+  integrity sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -2517,10 +2570,17 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-for-in@^1.0.2:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+for-own@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
+  integrity sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=
+  dependencies:
+    for-in "^1.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -2701,6 +2761,11 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
+getopts@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.2.4.tgz#3137fe8a5fddf304904059a851bdc1c22f0f54fb"
+  integrity sha512-Rz7DGyomZjrenu9Jx4qmzdlvJgvrEFHXHvjK0FcZtcTC1U5FmES7OdZHUwMuSnEE6QvBvwse1JODKj7TgbSEjQ==
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -2756,6 +2821,26 @@ global-dirs@^0.1.0, global-dirs@^0.1.1:
   integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
   dependencies:
     ini "^1.3.4"
+
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  integrity sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -2907,6 +2992,13 @@ has@^1.0.1, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+homedir-polyfill@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
+  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
+  dependencies:
+    parse-passwd "^1.0.0"
 
 hook-std@^2.0.0:
   version "2.0.0"
@@ -3061,7 +3153,7 @@ inflight@^1.0.4, inflight@~1.0.6:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3084,6 +3176,11 @@ init-package-json@^1.10.3:
     semver "2.x || 3.x || 4 || 5"
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
+
+interpret@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
 into-stream@^5.0.0:
   version "5.1.0"
@@ -3254,7 +3351,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -4021,6 +4118,27 @@ kleur@^3.0.2:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+knex@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.19.0.tgz#3c0383e70f01b35836079b8ef837fc6566c1aab3"
+  integrity sha512-4acpjPAugogM5KmffJ6wG2e9nrmDq6Xg4tWk0pEHJKfAnqBefMPD0Si9oA2aYzg3Fsfey5FvZYXEDNBsNHeVkw==
+  dependencies:
+    bluebird "^3.5.5"
+    colorette "1.0.8"
+    commander "^2.20.0"
+    debug "4.1.1"
+    getopts "2.2.4"
+    inherits "~2.0.4"
+    interpret "^1.2.0"
+    liftoff "3.1.0"
+    lodash "^4.17.14"
+    mkdirp "^0.5.1"
+    pg-connection-string "2.0.0"
+    tarn "^2.0.0"
+    tildify "2.0.0"
+    uuid "^3.3.2"
+    v8flags "^3.1.3"
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
@@ -4203,6 +4321,20 @@ libnpx@^10.2.0:
     which "^1.3.0"
     y18n "^4.0.0"
     yargs "^11.0.0"
+
+liftoff@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-3.1.0.tgz#c9ba6081f908670607ee79062d700df062c52ed3"
+  integrity sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==
+  dependencies:
+    extend "^3.0.0"
+    findup-sync "^3.0.0"
+    fined "^1.0.1"
+    flagged-respawn "^1.0.0"
+    is-plain-object "^2.0.4"
+    object.map "^1.0.0"
+    rechoir "^0.6.2"
+    resolve "^1.1.7"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -4460,7 +4592,7 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.11, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
@@ -4575,6 +4707,13 @@ make-fetch-happen@^4.0.1, make-fetch-happen@^4.0.2:
     socks-proxy-agent "^4.0.0"
     ssri "^6.0.0"
 
+make-iterator@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/make-iterator/-/make-iterator-1.0.1.tgz#29b33f312aa8f547c4a5e490f56afcec99133ad6"
+  integrity sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==
+  dependencies:
+    kind-of "^6.0.2"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -4589,7 +4728,7 @@ map-age-cleaner@^0.1.1:
   dependencies:
     p-defer "^1.0.0"
 
-map-cache@^0.2.2:
+map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
@@ -4701,7 +4840,7 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
 
-micromatch@^3.1.10, micromatch@^3.1.4:
+micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -5376,6 +5515,16 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
+object.defaults@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.defaults/-/object.defaults-1.1.0.tgz#3a7f868334b407dea06da16d88d5cd29e435fecf"
+  integrity sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=
+  dependencies:
+    array-each "^1.0.1"
+    array-slice "^1.0.0"
+    for-own "^1.0.0"
+    isobject "^3.0.0"
+
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
@@ -5384,7 +5533,15 @@ object.getownpropertydescriptors@^2.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.5.1"
 
-object.pick@^1.3.0:
+object.map@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object.map/-/object.map-1.0.1.tgz#cf83e59dc8fcc0ad5f4250e1f78b3b81bd801d37"
+  integrity sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=
+  dependencies:
+    for-own "^1.0.0"
+    make-iterator "^1.0.0"
+
+object.pick@^1.2.0, object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
@@ -5657,6 +5814,15 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-filepath@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
+  integrity sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=
+  dependencies:
+    is-absolute "^1.0.0"
+    map-cache "^0.2.0"
+    path-root "^0.1.1"
+
 parse-github-url@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/parse-github-url/-/parse-github-url-1.0.2.tgz#242d3b65cbcdda14bb50439e3242acf6971db395"
@@ -5679,6 +5845,11 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
     lines-and-columns "^1.1.6"
+
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
 parse5@4.0.0:
   version "4.0.0"
@@ -5725,6 +5896,18 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+  integrity sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
+  dependencies:
+    path-root-regex "^0.1.0"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -5751,6 +5934,11 @@ pg-connection-string@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
   integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
+
+pg-connection-string@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.0.0.tgz#3eefe5997e06d94821e4d502e42b6a1c73f8df82"
+  integrity sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I=
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -6199,6 +6387,13 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 redent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
@@ -6342,6 +6537,14 @@ resolve-cwd@^2.0.0:
   dependencies:
     resolve-from "^3.0.0"
 
+resolve-dir@^1.0.0, resolve-dir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  integrity sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@5.0.0, resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
@@ -6379,7 +6582,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
+resolve@1.x, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
@@ -7105,6 +7308,11 @@ tar@^4, tar@^4.4.10, tar@^4.4.8:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
+tarn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tarn/-/tarn-2.0.0.tgz#c68499f69881f99ae955b4317ca7d212d942fdee"
+  integrity sha512-7rNMCZd3s9bhQh47ksAQd92ADFcJUjjbyOvyFjNLwTPpGieFHMC84S+LOzw0fx1uh6hnDz/19r8CPMnIjJlMMA==
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -7149,6 +7357,11 @@ through@2, "through@>=2.2.7 <3":
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tildify@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
+  integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
 
 timed-out@^4.0.0:
   version "4.0.1"
@@ -7524,6 +7737,13 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+v8flags@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
+  integrity sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -7609,7 +7829,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1, which@^1.2.9, which@^1.3.0, which@^1.3.1:
+which@1, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
QueryBuilder now internally uses knex to run all queries. As knex already supports connection pooling, this feature comes without any effort. New configuration for pooling is now availableAs knex already supports connection pooling, this feature comes without any effort.

**BREAKING CHANGES:**
- Transactions now require using EM.transactional() method, previous helpers `beginTransaction/commit/rollback` are now removed. 
- All transaction management has been removed from IDatabaseDriver interface, now EM handles this, passing the transaction context (carried by EM, and created by Connection) to all driver methods. New methods on EM exists: `isInTransaction` and `getTransactionContext`.
- Because of knex being used as a query runner, there are some minor differences in results of plain sql calls (made by calling connection.execute() with string sql parameter instead of using QueryBuilder). 
- Another difference is in postgre driver, that used to require passing parameters as indexed dollar sign ($1, $2, ...), while now knex requires the placeholder to be simple question mark (?), like in other dialects, so this is now unified with other drivers.

Closes #64 

**TODO:**
- [x] Refactor QueryBuilderHelper, maybe introduce KnexQuery object to help with instrumenting knex' QueryBuilder
- [x] Use knex in SchemaGenerator (partially blocked by https://github.com/tgriesser/knex/issues/3351)
- [ ] Document differences