### PR TITLE
feat(schema): use knex in schema generator

### DIFF
--- a/lib/MikroORM.ts
+++ b/lib/MikroORM.ts
@@ -1,7 +1,8 @@
 import { EntityManager } from './EntityManager';
-import { IDatabaseDriver } from './drivers';
+import { AbstractSqlDriver, IDatabaseDriver } from './drivers';
 import { MetadataDiscovery, MetadataStorage } from './metadata';
 import { Configuration, Logger, Options } from './utils';
+import { SchemaGenerator } from './schema';
 
 export class MikroORM {
 
@@ -60,6 +61,10 @@ export class MikroORM {
 
   getMetadata(): MetadataStorage {
     return this.metadata;
+  }
+
+  getSchemaGenerator(): SchemaGenerator {
+    return new SchemaGenerator(this.driver as AbstractSqlDriver, this.metadata);
   }
 
 }

--- a/lib/decorators/Entity.ts
+++ b/lib/decorators/Entity.ts
@@ -60,6 +60,7 @@ export interface EntityProperty<T extends IEntityType<T> = any> {
   name: string & keyof T;
   entity: () => EntityName<T>;
   type: string;
+  columnType: string;
   primary: boolean;
   length?: any;
   reference: ReferenceType;

--- a/lib/metadata/MetadataDiscovery.ts
+++ b/lib/metadata/MetadataDiscovery.ts
@@ -13,6 +13,7 @@ export class MetadataDiscovery {
   private readonly namingStrategy = this.config.getNamingStrategy();
   private readonly metadataProvider = this.config.getMetadataProvider();
   private readonly cache = this.config.getCacheAdapter();
+  private readonly schemaHelper = this.platform.getSchemaHelper();
   private readonly validator = new MetadataValidator();
   private readonly discovered: EntityMetadata[] = [];
 
@@ -204,6 +205,7 @@ export class MetadataDiscovery {
     this.validator.validateEntityDefinition(this.metadata, meta.name);
     Object.values(meta.properties).forEach(prop => {
       this.applyNamingStrategy(meta, prop);
+      this.initColumnType(prop);
 
       if (prop.version) {
         meta.versionProperty = prop.name;
@@ -231,6 +233,7 @@ export class MetadataDiscovery {
       const pk = this.namingStrategy.referenceColumnName();
       const primaryProp = { name: pk, type: 'number', reference: ReferenceType.SCALAR, primary: true, unsigned: true } as EntityProperty;
       this.initFieldName(primaryProp);
+      this.initColumnType(primaryProp);
 
       return this.metadata.set(prop.pivotTable, {
         name: prop.pivotTable,
@@ -269,6 +272,8 @@ export class MetadataDiscovery {
       ret.inverseJoinColumn = prop.referenceColumnName;
     }
 
+    this.initColumnType(ret);
+
     return ret;
   }
 
@@ -298,6 +303,20 @@ export class MetadataDiscovery {
     }
 
     return 1;
+  }
+
+  private initColumnType(prop: EntityProperty): void {
+    if (prop.columnType || !this.schemaHelper) {
+      return;
+    }
+
+    if (prop.reference === ReferenceType.SCALAR) {
+      prop.columnType = this.schemaHelper.getTypeDefinition(prop);
+      return;
+    }
+
+    const meta = this.metadata.get(prop.type);
+    prop.columnType = this.schemaHelper.getTypeDefinition(meta.properties[meta.primaryKey]);
   }
 
 }

--- a/lib/platforms/MongoPlatform.ts
+++ b/lib/platforms/MongoPlatform.ts
@@ -6,7 +6,7 @@ import { SchemaHelper } from '../schema';
 
 export class MongoPlatform extends Platform {
 
-  protected schemaHelper: SchemaHelper;
+  protected readonly schemaHelper?: SchemaHelper;
 
   usesPivotTable(): boolean {
     return false;
@@ -34,10 +34,6 @@ export class MongoPlatform extends Platform {
 
   getSerializedPrimaryKeyField(field: string): string {
     return 'id';
-  }
-
-  getSchemaHelper(): SchemaHelper {
-    throw new Error(`${MongoPlatform.name} does not provide SchemaHelper`);
   }
 
 }

--- a/lib/platforms/MySqlPlatform.ts
+++ b/lib/platforms/MySqlPlatform.ts
@@ -3,6 +3,6 @@ import { MySqlSchemaHelper } from '../schema/MySqlSchemaHelper';
 
 export class MySqlPlatform extends Platform {
 
-  protected schemaHelper = new MySqlSchemaHelper();
+  protected readonly schemaHelper = new MySqlSchemaHelper();
 
 }

--- a/lib/platforms/Platform.ts
+++ b/lib/platforms/Platform.ts
@@ -4,7 +4,7 @@ import { SchemaHelper } from '../schema';
 
 export abstract class Platform {
 
-  protected abstract schemaHelper: SchemaHelper;
+  protected readonly abstract schemaHelper?: SchemaHelper;
 
   usesPivotTable(): boolean {
     return true;
@@ -26,7 +26,7 @@ export abstract class Platform {
     return false;
   }
 
-  getSchemaHelper(): SchemaHelper {
+  getSchemaHelper(): SchemaHelper | undefined {
     return this.schemaHelper;
   }
 

--- a/lib/platforms/PostgreSqlPlatform.ts
+++ b/lib/platforms/PostgreSqlPlatform.ts
@@ -3,7 +3,7 @@ import { PostgreSqlSchemaHelper } from '../schema/PostgreSqlSchemaHelper';
 
 export class PostgreSqlPlatform extends Platform {
 
-  protected schemaHelper = new PostgreSqlSchemaHelper();
+  protected readonly schemaHelper = new PostgreSqlSchemaHelper();
 
   usesReturningStatement(): boolean {
     return true;

--- a/lib/platforms/SqlitePlatform.ts
+++ b/lib/platforms/SqlitePlatform.ts
@@ -3,7 +3,7 @@ import { SqliteSchemaHelper } from '../schema/SqliteSchemaHelper';
 
 export class SqlitePlatform extends Platform {
 
-  protected schemaHelper = new SqliteSchemaHelper();
+  protected readonly schemaHelper = new SqliteSchemaHelper();
 
   requiresNullableForAlteringColumn() {
     return true;

--- a/lib/schema/MySqlSchemaHelper.ts
+++ b/lib/schema/MySqlSchemaHelper.ts
@@ -1,18 +1,18 @@
+import { ColumnInfo, MySqlTableBuilder } from 'knex';
 import { SchemaHelper } from './SchemaHelper';
 import { EntityProperty } from '../decorators';
-import { MySqlTableBuilder } from 'knex';
 
 export class MySqlSchemaHelper extends SchemaHelper {
 
   static readonly TYPES = {
-    number: 'int(?)',
-    float: 'float',
-    double: 'double',
-    string: 'varchar(?)',
-    date: 'datetime(?)',
-    boolean: 'tinyint(1)',
-    text: 'text',
-    json: 'json',
+    number: ['int(?)', 'float', 'double'],
+    float: ['float'],
+    double: ['double'],
+    string: ['varchar(?)', 'text'],
+    date: ['datetime(?)', 'timestamp(?)'],
+    boolean: ['tinyint(1)'],
+    text: ['text'],
+    json: ['json'],
   };
 
   static readonly DEFAULT_TYPE_LENGTHS = {

--- a/lib/schema/PostgreSqlSchemaHelper.ts
+++ b/lib/schema/PostgreSqlSchemaHelper.ts
@@ -1,17 +1,23 @@
+import { ColumnInfo } from 'knex';
 import { SchemaHelper } from './SchemaHelper';
 import { EntityProperty } from '../decorators';
 
 export class PostgreSqlSchemaHelper extends SchemaHelper {
 
   static readonly TYPES = {
-    number: 'int',
-    float: 'float',
-    double: 'double precision',
-    string: 'varchar(?)',
-    date: 'timestamp(?)',
-    boolean: 'boolean',
-    text: 'text',
-    json: 'json',
+    number: ['int', 'int8', 'integer', 'float', 'float8', 'double', 'double precision', 'bigint', 'smallint', 'decimal', 'numeric', 'real'],
+    float: ['float'],
+    double: ['double', 'double precision', 'float8'],
+    string: ['varchar(?)', 'character varying', 'text', 'character', 'char'],
+    date: ['datetime(?)', 'timestamp(?)', 'timestamp without time zone', 'timestamptz', 'datetimetz', 'time', 'date', 'timetz', 'datetz'],
+    boolean: ['boolean', 'bool'],
+    text: ['text'],
+    json: ['json'],
+  };
+
+  static readonly DEFAULT_VALUES = {
+    'now()': ['now()', 'current_timestamp'],
+    "('now'::text)::timestamp(?) with time zone": ['current_timestamp(?)'],
   };
 
   static readonly DEFAULT_TYPE_LENGTHS = {

--- a/lib/schema/SchemaGenerator.ts
+++ b/lib/schema/SchemaGenerator.ts
@@ -1,4 +1,4 @@
-import { ColumnBuilder, TableBuilder } from 'knex';
+import { ColumnBuilder, SchemaBuilder, TableBuilder } from 'knex';
 import { AbstractSqlDriver, Cascade, ReferenceType, Utils } from '..';
 import { EntityMetadata, EntityProperty } from '../decorators';
 import { Platform } from '../platforms';
@@ -7,39 +7,95 @@ import { MetadataStorage } from '../metadata';
 export class SchemaGenerator {
 
   private readonly platform: Platform = this.driver.getPlatform();
-  private readonly helper = this.platform.getSchemaHelper();
-  private readonly knex = this.driver.getConnection().getKnex();
+  private readonly helper = this.platform.getSchemaHelper()!;
+  private readonly connection = this.driver.getConnection();
+  private readonly knex = this.connection.getKnex();
 
   constructor(private readonly driver: AbstractSqlDriver,
               private readonly metadata: MetadataStorage) { }
 
-  generate(): string {
+  async generate(): Promise<string> {
+    let ret = await this.getDropSchemaSQL(false);
+    ret += await this.getCreateSchemaSQL(false);
+
+    return this.wrapSchema(ret);
+  }
+
+  async createSchema(wrap = true): Promise<void> {
+    const sql = await this.getCreateSchemaSQL(wrap);
+    await this.execute(sql);
+  }
+
+  async getCreateSchemaSQL(wrap = true): Promise<string> {
+    let ret = '';
+
+    for (const meta of Object.values(this.metadata.getAll())) {
+      ret += this.dump(this.createTable(meta));
+    }
+
+    for (const meta of Object.values(this.metadata.getAll())) {
+      ret += this.dump(this.knex.schema.alterTable(meta.collection, table => this.createForeignKeys(table, meta)));
+    }
+
+    return this.wrapSchema(ret, wrap);
+  }
+
+  async dropSchema(wrap = true): Promise<void> {
+    const sql = await this.getDropSchemaSQL(wrap);
+    await this.execute(sql);
+  }
+
+  async getDropSchemaSQL(wrap = true): Promise<string> {
+    let ret = '';
+
+    for (const meta of Object.values(this.metadata.getAll())) {
+      ret += this.dump(this.dropTable(meta.collection), '\n');
+    }
+
+    return this.wrapSchema(ret + '\n', wrap);
+  }
+
+  async execute(sql: string) {
+    const lines = sql.split('\n').filter(i => i.trim());
+
+    for (const line of lines) {
+      await this.connection.getKnex().schema.raw(line);
+    }
+  }
+
+  private async wrapSchema(sql: string, wrap = true): Promise<string> {
+    if (!wrap) {
+      return sql;
+    }
+
     let ret = this.helper.getSchemaBeginning();
-
-    Object.values(this.metadata.getAll()).forEach(meta => ret += this.knex.schema.dropTableIfExists(meta.collection).toQuery() + ';\n');
-    ret += '\n';
-    Object.values(this.metadata.getAll()).forEach(meta => ret += this.createTable(meta));
-    Object.values(this.metadata.getAll()).forEach(meta => {
-      const alter = this.knex.schema.alterTable(meta.collection, table => this.createForeignKeys(table, meta)).toQuery();
-      ret += alter ? alter + ';\n\n' : '';
-    });
-
+    ret += sql;
     ret += this.helper.getSchemaEnd();
 
     return ret;
   }
 
-  private createTable(meta: EntityMetadata): string {
+  private createTable(meta: EntityMetadata): SchemaBuilder {
     return this.knex.schema.createTable(meta.collection, table => {
       Object
         .values(meta.properties)
         .filter(prop => this.shouldHaveColumn(prop))
         .forEach(prop => this.createTableColumn(table, prop));
       this.helper.finalizeTable(table);
-    }).toQuery() + ';\n\n';
+    });
   }
 
-  private shouldHaveColumn(prop: EntityProperty): boolean {
+  private dropTable(name: string): SchemaBuilder {
+    let builder = this.knex.schema.dropTableIfExists(name);
+
+    if (this.platform.usesCascadeStatement()) {
+      builder = this.knex.schema.raw(builder.toQuery() + ' cascade');
+    }
+
+    return builder;
+  }
+
+  private shouldHaveColumn(prop: EntityProperty, update = false): boolean {
     if (prop.persist === false) {
       return false;
     }
@@ -48,7 +104,7 @@ export class SchemaGenerator {
       return true;
     }
 
-    if (!this.helper.supportsSchemaConstraints()) {
+    if (!this.helper.supportsSchemaConstraints() && !update) {
       return false;
     }
 
@@ -60,8 +116,7 @@ export class SchemaGenerator {
       return table.increments(prop.fieldName);
     }
 
-    const type = this.type(prop);
-    const col = table.specificType(prop.fieldName, type);
+    const col = table.specificType(prop.fieldName, prop.columnType);
     this.configureColumn(prop, col, alter);
 
     return col;
@@ -121,13 +176,9 @@ export class SchemaGenerator {
     }
   }
 
-  private type(prop: EntityProperty): string {
-    if (prop.reference === ReferenceType.SCALAR) {
-      return this.helper.getTypeDefinition(prop);
-    }
-
-    const meta = this.metadata.get(prop.type);
-    return this.helper.getTypeDefinition(meta.properties[meta.primaryKey]);
+  private dump(builder: SchemaBuilder, append = '\n\n'): string {
+    const sql = builder.toQuery();
+    return sql.length > 0 ? `${sql};${append}` : '';
   }
 
 }

--- a/lib/schema/SchemaHelper.ts
+++ b/lib/schema/SchemaHelper.ts
@@ -1,4 +1,4 @@
-import { TableBuilder } from 'knex';
+import { ColumnInfo, TableBuilder } from 'knex';
 import { EntityProperty } from '../decorators';
 
 export abstract class SchemaHelper {
@@ -15,9 +15,9 @@ export abstract class SchemaHelper {
     //
   }
 
-  getTypeDefinition(prop: EntityProperty, types: Record<string, string> = {}, lengths: Record<string, number> = {}): string {
+  getTypeDefinition(prop: EntityProperty, types: Record<string, string[]> = {}, lengths: Record<string, number> = {}): string {
     const t = prop.type.toLowerCase();
-    let type = types[t] || types.json || types.text || t;
+    let type = (types[t] || types.json || types.text || [t])[0];
 
     if (type.includes('(?)')) {
       const length = prop.length || lengths[t];

--- a/lib/schema/SqliteSchemaHelper.ts
+++ b/lib/schema/SqliteSchemaHelper.ts
@@ -1,13 +1,14 @@
 import { SchemaHelper } from './SchemaHelper';
 import { EntityProperty } from '../decorators';
+import { ColumnInfo } from 'knex';
 
 export class SqliteSchemaHelper extends SchemaHelper {
 
   static readonly TYPES = {
-    number: 'integer',
-    boolean: 'integer',
-    date: 'text',
-    string: 'text',
+    number: ['integer'],
+    boolean: ['integer'],
+    date: ['text'],
+    string: ['text'],
   };
 
   getSchemaBeginning(): string {
@@ -20,7 +21,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
 
   getTypeDefinition(prop: EntityProperty): string {
     const t = prop.type.toLowerCase() as keyof typeof SqliteSchemaHelper.TYPES;
-    return SqliteSchemaHelper.TYPES[t] || SqliteSchemaHelper.TYPES.string;
+    return (SqliteSchemaHelper.TYPES[t] || SqliteSchemaHelper.TYPES.string)[0];
   }
 
   supportsSchemaConstraints(): boolean {

--- a/lib/utils/Configuration.ts
+++ b/lib/utils/Configuration.ts
@@ -1,3 +1,4 @@
+import { PoolConfig } from 'knex';
 import { NamingStrategy } from '../naming-strategy';
 import { CacheAdapter, FileCacheAdapter, NullCacheAdapter } from '../cache';
 import { MetadataProvider, TypeScriptMetadataProvider } from '../metadata';
@@ -8,7 +9,6 @@ import { Logger, Utils } from '../utils';
 import { EntityManager } from '../EntityManager';
 import { IDatabaseDriver } from '..';
 import { Platform } from '../platforms';
-import { PoolConfig } from 'knex';
 
 export class Configuration {
 

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -2,7 +2,7 @@ import { ObjectId } from 'mongodb';
 import { Book, Author, Publisher } from './entities';
 import { MikroORM, Collection, Utils } from '../lib';
 import { EntityFactory, ReferenceType } from '../lib/entity';
-import { initORM, wipeDatabase } from './bootstrap';
+import { initORMMongo, wipeDatabase } from './bootstrap';
 import { MetadataDiscovery } from '../lib/metadata';
 
 describe('EntityFactory', () => {
@@ -11,7 +11,7 @@ describe('EntityFactory', () => {
   let factory: EntityFactory;
 
   beforeAll(async () => {
-    orm = await initORM();
+    orm = await initORMMongo();
     await new MetadataDiscovery(orm.getMetadata(), orm.em.getDriver().getPlatform(), orm.config, orm.config.getLogger()).discover();
     factory = new EntityFactory(orm.em.getUnitOfWork(), orm.em.getDriver(), orm.config, orm.getMetadata());
     expect(orm.em.config.getNamingStrategy().referenceColumnName()).toBe('_id');

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -1,13 +1,13 @@
 import { ObjectId } from 'mongodb';
 import { Author, Book, BookTag, Publisher, Test } from './entities';
 import { EntityAssigner, EntityHelper, MikroORM } from '../lib';
-import { initORM, wipeDatabase } from './bootstrap';
+import { initORMMongo, wipeDatabase } from './bootstrap';
 
 describe('EntityAssignerMongo', () => {
 
   let orm: MikroORM;
 
-  beforeAll(async () => orm = await initORM());
+  beforeAll(async () => orm = await initORMMongo());
   beforeEach(async () => wipeDatabase(orm.em));
 
   test('#toObject() should return DTO', async () => {

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -3,7 +3,7 @@ import { Collection, Configuration, EntityManager, MikroORM, QueryOrder } from '
 import { EntityProperty } from '../lib/decorators';
 import { Author, Book, BookTag, Publisher, PublisherType, Test } from './entities';
 import { AuthorRepository } from './repositories/AuthorRepository';
-import { initORM, wipeDatabase } from './bootstrap';
+import { initORMMongo, wipeDatabase } from './bootstrap';
 import { MongoDriver } from '../lib/drivers/MongoDriver';
 import { MongoConnection } from '../lib/connections/MongoConnection';
 import { Logger } from '../lib/utils';
@@ -14,7 +14,7 @@ describe('EntityManagerMongo', () => {
 
   let orm: MikroORM;
 
-  beforeAll(async () => orm = await initORM());
+  beforeAll(async () => orm = await initORMMongo());
   beforeEach(async () => wipeDatabase(orm.em));
 
   test('should load entities', async () => {
@@ -345,7 +345,6 @@ describe('EntityManagerMongo', () => {
     expect(driver.getPlatform().usesPivotTable()).toBe(false);
     expect(driver.getPlatform().requiresNullableForAlteringColumn()).toBe(false); // test default Platform value (not used by mongo)
     await expect(driver.loadFromPivotTable({} as EntityProperty, [])).rejects.toThrowError('MongoDriver does not use pivot tables');
-    expect(() => driver.getPlatform().getSchemaHelper()).toThrowError('MongoPlatform does not provide SchemaHelper');
     await expect(driver.getConnection().execute('')).rejects.toThrowError('MongoConnection does not support generic execute method');
     expect(driver.getConnection().getCollection(BookTag).collectionName).toBe('book-tag');
     expect(driver.getConnection().getCollection(BookTag.name).collectionName).toBe('book-tag');

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -1,4 +1,4 @@
-import { MikroORM, EntityManager, Configuration } from '../lib';
+import { MikroORM, EntityManager, Configuration, SchemaGenerator } from '../lib';
 import { Author } from './entities';
 import { BASE_DIR } from './bootstrap';
 import { FooBaz2 } from './entities-sql';
@@ -33,6 +33,7 @@ describe('MikroORM', () => {
 
     expect(orm).toBeInstanceOf(MikroORM);
     expect(orm.em).toBeInstanceOf(EntityManager);
+    expect(Object.keys(orm.getMetadata().getAll()).sort()).toEqual(['Author', 'Book', 'BookTag', 'FooBar', 'FooBaz', 'Publisher', 'Test']);
     expect(await orm.isConnected()).toBe(true);
 
     await orm.close();

--- a/tests/RequestContext.test.ts
+++ b/tests/RequestContext.test.ts
@@ -1,12 +1,12 @@
 import { RequestContext, MikroORM } from '../lib';
-import { initORM, wipeDatabase } from './bootstrap';
+import { initORMMongo, wipeDatabase } from './bootstrap';
 import { Author, Book } from './entities';
 
 describe('RequestContext', () => {
 
   let orm: MikroORM;
 
-  beforeAll(async () => orm = await initORM());
+  beforeAll(async () => orm = await initORMMongo());
   beforeEach(async () => wipeDatabase(orm.em));
 
   test('create new context', async () => {

--- a/tests/SchemaGenerator.test.ts
+++ b/tests/SchemaGenerator.test.ts
@@ -5,25 +5,48 @@ describe('SchemaGenerator', () => {
 
   test('generate schema from metadata [mysql]', async () => {
     const orm = await initORMMySql();
-    const generator = new SchemaGenerator(orm.em.getDriver(), orm.getMetadata());
-    const dump = generator.generate();
+    const generator = orm.getSchemaGenerator();
+    const dump = await generator.generate();
     expect(dump).toMatchSnapshot('mysql-schema-dump');
+
+    const dropDump = await generator.getDropSchemaSQL();
+    expect(dropDump).toMatchSnapshot('mysql-drop-schema-dump');
+
+    const createDump = await generator.getCreateSchemaSQL();
+    expect(createDump).toMatchSnapshot('mysql-create-schema-dump');
+
     await orm.close(true);
   });
 
   test('generate schema from metadata [sqlite]', async () => {
     const orm = await initORMSqlite();
-    const generator = new SchemaGenerator(orm.em.getDriver(), orm.getMetadata());
-    const dump = generator.generate();
+    const generator = orm.getSchemaGenerator();
+    const dump = await generator.generate();
     expect(dump).toMatchSnapshot('sqlite-schema-dump');
+
+    const dropDump = await generator.getDropSchemaSQL();
+    expect(dropDump).toMatchSnapshot('sqlite-drop-schema-dump');
+    await generator.dropSchema();
+
+    const createDump = await generator.getCreateSchemaSQL();
+    expect(createDump).toMatchSnapshot('sqlite-create-schema-dump');
+    await generator.createSchema();
+
     await orm.close(true);
   });
 
   test('generate schema from metadata [postgres]', async () => {
     const orm = await initORMPostgreSql();
-    const generator = new SchemaGenerator(orm.em.getDriver(), orm.getMetadata());
-    const dump = generator.generate();
+    const generator = orm.getSchemaGenerator();
+    const dump = await generator.generate();
     expect(dump).toMatchSnapshot('postgres-schema-dump');
+
+    const dropDump = await generator.getDropSchemaSQL();
+    expect(dropDump).toMatchSnapshot('postgres-drop-schema-dump');
+
+    const createDump = await generator.getCreateSchemaSQL();
+    expect(createDump).toMatchSnapshot('postgres-create-schema-dump');
+
     await orm.close(true);
   });
 

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -1,7 +1,7 @@
 import { Author } from './entities';
 import { EntityValidator, MikroORM } from '../lib';
 import { UnitOfWork, ChangeSetComputer } from '../lib/unit-of-work';
-import { initORM, wipeDatabase } from './bootstrap';
+import { initORMMongo, wipeDatabase } from './bootstrap';
 
 describe('UnitOfWork', () => {
 
@@ -10,7 +10,7 @@ describe('UnitOfWork', () => {
   let computer: ChangeSetComputer;
 
   beforeAll(async () => {
-    orm = await initORM();
+    orm = await initORMMongo();
     uow = new UnitOfWork(orm.em);
     // @ts-ignore
     computer = uow.changeSetComputer;

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 import { Collection, MikroORM, Utils } from '../lib';
 import { Author, Book } from './entities';
-import { initORM, wipeDatabase } from './bootstrap';
+import { initORMMongo, wipeDatabase } from './bootstrap';
 import { EntityMetadata } from '../lib/decorators';
 
 class Test {}
@@ -10,7 +10,7 @@ describe('Utils', () => {
 
   let orm: MikroORM;
 
-  beforeAll(async () => orm = await initORM());
+  beforeAll(async () => orm = await initORMMongo());
   beforeEach(async () => wipeDatabase(orm.em));
 
   test('isObject', () => {

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -1,18 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-schema-dump 1`] = `
+exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-create-schema-dump 1`] = `
 "set names utf8;
 set foreign_key_checks = 0;
-
-drop table if exists \`author2\`;
-drop table if exists \`book2\`;
-drop table if exists \`book_tag2\`;
-drop table if exists \`publisher2\`;
-drop table if exists \`test2\`;
-drop table if exists \`foo_bar2\`;
-drop table if exists \`foo_baz2\`;
-drop table if exists \`book2_to_book_tag2\`;
-drop table if exists \`publisher2_to_test2\`;
 
 create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null, \`terms_accepted\` tinyint(1) not null default 0, \`identities\` json null, \`born\` datetime null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
 alter table \`author2\` add unique \`author2_email_unique\`(\`email\`);
@@ -32,7 +22,7 @@ create table \`test2\` (\`id\` int unsigned not null auto_increment primary key,
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
 alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
@@ -69,24 +59,101 @@ set foreign_key_checks = 1;
 "
 `;
 
-exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-schema-dump 1`] = `
+exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-drop-schema-dump 1`] = `
+"set names utf8;
+set foreign_key_checks = 0;
+
+drop table if exists \`author2\`;
+drop table if exists \`book2\`;
+drop table if exists \`book_tag2\`;
+drop table if exists \`publisher2\`;
+drop table if exists \`test2\`;
+drop table if exists \`foo_bar2\`;
+drop table if exists \`foo_baz2\`;
+drop table if exists \`book2_to_book_tag2\`;
+drop table if exists \`publisher2_to_test2\`;
+
+set foreign_key_checks = 1;
+"
+`;
+
+exports[`SchemaGenerator generate schema from metadata [mysql]: mysql-schema-dump 1`] = `
+"set names utf8;
+set foreign_key_checks = 0;
+
+drop table if exists \`author2\`;
+drop table if exists \`book2\`;
+drop table if exists \`book_tag2\`;
+drop table if exists \`publisher2\`;
+drop table if exists \`test2\`;
+drop table if exists \`foo_bar2\`;
+drop table if exists \`foo_baz2\`;
+drop table if exists \`book2_to_book_tag2\`;
+drop table if exists \`publisher2_to_test2\`;
+
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int(11) null, \`terms_accepted\` tinyint(1) not null default 0, \`identities\` json null, \`born\` datetime null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table \`author2\` add unique \`author2_email_unique\`(\`email\`);
+alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);
+alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favourite_author_id\`);
+
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null, \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned null, \`publisher_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
+alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
+alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
+
+create table \`book_tag2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8 engine = InnoDB;
+
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`type\` varchar(10) not null) default character set utf8 engine = InnoDB;
+
+create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`version\` int(11) not null default 1) default character set utf8 engine = InnoDB;
+alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
+alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
+alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8 engine = InnoDB;
+
+create table \`book2_to_book_tag2\` (\`id\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
+alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book_tag2_id_index\`(\`book_tag2_id\`);
+
+create table \`publisher2_to_test2\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int(11) unsigned not null, \`test2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table \`publisher2_to_test2\` add index \`publisher2_to_test2_publisher2_id_index\`(\`publisher2_id\`);
+alter table \`publisher2_to_test2\` add index \`publisher2_to_test2_test2_id_index\`(\`test2_id\`);
+
+alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete set null;
+alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on delete set null;
+alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on delete set null;
+
+alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on update cascade on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete set null;
+
+alter table \`book2_to_book_tag2\` add constraint \`book2_to_book_tag2_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
+alter table \`book2_to_book_tag2\` add constraint \`book2_to_book_tag2_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`publisher2_to_test2\` add constraint \`publisher2_to_test2_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_to_test2\` add constraint \`publisher2_to_test2_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
+
+set foreign_key_checks = 1;
+"
+`;
+
+exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-create-schema-dump 1`] = `
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-drop table if exists \\"author2\\";
-drop table if exists \\"book2\\";
-drop table if exists \\"book_tag2\\";
-drop table if exists \\"publisher2\\";
-drop table if exists \\"test2\\";
-drop table if exists \\"foo_bar2\\";
-drop table if exists \\"foo_baz2\\";
-drop table if exists \\"book2_to_book_tag2\\";
-drop table if exists \\"publisher2_to_test2\\";
-
-create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"updated_at\\" timestamp(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int null, \\"terms_accepted\\" boolean not null default 0, \\"identities\\" json null, \\"born\\" timestamp null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int null);
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" datetime(3) not null default current_timestamp(3), \\"updated_at\\" datetime(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int null, \\"terms_accepted\\" boolean not null default 0, \\"identities\\" json null, \\"born\\" datetime null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int null);
 alter table \\"author2\\" add constraint \\"author2_email_unique\\" unique (\\"email\\");
 
-create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double precision null, \\"meta\\" json null, \\"author_id\\" int null, \\"publisher_id\\" int null);
+create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" datetime(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double null, \\"meta\\" json null, \\"author_id\\" int null, \\"publisher_id\\" int null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
 create table \\"book_tag2\\" (\\"id\\" serial primary key, \\"name\\" varchar(50) not null);
@@ -96,7 +163,7 @@ create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(2
 create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int null, \\"foo_bar_id\\" int null, \\"version\\" timestamp(3) not null default current_timestamp(3));
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int null, \\"foo_bar_id\\" int null, \\"version\\" datetime not null default current_timestamp(3));
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
@@ -124,6 +191,137 @@ alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_publ
 alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
 
 set session_replication_role = 'origin';
+"
+`;
+
+exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-drop-schema-dump 1`] = `
+"set names 'utf8';
+set session_replication_role = 'replica';
+
+drop table if exists \\"author2\\" cascade;
+drop table if exists \\"book2\\" cascade;
+drop table if exists \\"book_tag2\\" cascade;
+drop table if exists \\"publisher2\\" cascade;
+drop table if exists \\"test2\\" cascade;
+drop table if exists \\"foo_bar2\\" cascade;
+drop table if exists \\"foo_baz2\\" cascade;
+drop table if exists \\"book2_to_book_tag2\\" cascade;
+drop table if exists \\"publisher2_to_test2\\" cascade;
+
+set session_replication_role = 'origin';
+"
+`;
+
+exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-schema-dump 1`] = `
+"set names 'utf8';
+set session_replication_role = 'replica';
+
+drop table if exists \\"author2\\" cascade;
+drop table if exists \\"book2\\" cascade;
+drop table if exists \\"book_tag2\\" cascade;
+drop table if exists \\"publisher2\\" cascade;
+drop table if exists \\"test2\\" cascade;
+drop table if exists \\"foo_bar2\\" cascade;
+drop table if exists \\"foo_baz2\\" cascade;
+drop table if exists \\"book2_to_book_tag2\\" cascade;
+drop table if exists \\"publisher2_to_test2\\" cascade;
+
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" datetime(3) not null default current_timestamp(3), \\"updated_at\\" datetime(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int null, \\"terms_accepted\\" boolean not null default 0, \\"identities\\" json null, \\"born\\" datetime null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int null);
+alter table \\"author2\\" add constraint \\"author2_email_unique\\" unique (\\"email\\");
+
+create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" datetime(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double null, \\"meta\\" json null, \\"author_id\\" int null, \\"publisher_id\\" int null);
+alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
+
+create table \\"book_tag2\\" (\\"id\\" serial primary key, \\"name\\" varchar(50) not null);
+
+create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" varchar(10) not null);
+
+create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int not null default 1);
+alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
+
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int null, \\"foo_bar_id\\" int null, \\"version\\" datetime not null default current_timestamp(3));
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
+
+create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null);
+
+create table \\"book2_to_book_tag2\\" (\\"id\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int not null);
+
+create table \\"publisher2_to_test2\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int not null, \\"test2_id\\" int not null);
+
+alter table \\"author2\\" add constraint \\"author2_favourite_book_uuid_pk_foreign\\" foreign key (\\"favourite_book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete set null;
+alter table \\"author2\\" add constraint \\"author2_favourite_author_id_foreign\\" foreign key (\\"favourite_author_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete set null;
+
+alter table \\"book2\\" add constraint \\"book2_author_id_foreign\\" foreign key (\\"author_id\\") references \\"author2\\" (\\"id\\") on delete set null;
+alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on delete set null;
+
+alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
+
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_foreign\\" foreign key (\\"baz_id\\") references \\"foo_baz2\\" (\\"id\\") on update cascade on delete set null;
+alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_foreign\\" foreign key (\\"foo_bar_id\\") references \\"foo_bar2\\" (\\"id\\") on update cascade on delete set null;
+
+alter table \\"book2_to_book_tag2\\" add constraint \\"book2_to_book_tag2_book2_uuid_pk_foreign\\" foreign key (\\"book2_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete cascade;
+alter table \\"book2_to_book_tag2\\" add constraint \\"book2_to_book_tag2_book_tag2_id_foreign\\" foreign key (\\"book_tag2_id\\") references \\"book_tag2\\" (\\"id\\") on update cascade on delete cascade;
+
+alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_publisher2_id_foreign\\" foreign key (\\"publisher2_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
+alter table \\"publisher2_to_test2\\" add constraint \\"publisher2_to_test2_test2_id_foreign\\" foreign key (\\"test2_id\\") references \\"test2\\" (\\"id\\") on update cascade on delete cascade;
+
+set session_replication_role = 'origin';
+"
+`;
+
+exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-create-schema-dump 1`] = `
+"pragma foreign_keys = off;
+
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` text null, \`updated_at\` text null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` text null);
+create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
+
+create table \`book3\` (\`id\` integer not null primary key autoincrement, \`title\` text not null);
+
+create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`version\` text not null default current_timestamp);
+
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`type\` text not null);
+
+create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` text null, \`version\` integer not null default 1);
+
+create table \`book3_to_book_tag3\` (\`id\` integer not null primary key autoincrement);
+
+create table \`publisher3_to_test3\` (\`id\` integer not null primary key autoincrement);
+
+alter table \`author3\` add column \`favourite_book_id\` integer null;
+create index \`author3_favourite_book_id_index\` on \`author3\` (\`favourite_book_id\`);
+
+alter table \`book3\` add column \`author_id\` integer null;
+alter table \`book3\` add column \`publisher_id\` integer null;
+create index \`book3_author_id_index\` on \`book3\` (\`author_id\`);
+create index \`book3_publisher_id_index\` on \`book3\` (\`publisher_id\`);
+
+alter table \`book3_to_book_tag3\` add column \`book3_id\` integer null;
+alter table \`book3_to_book_tag3\` add column \`book_tag3_id\` integer null;
+create index \`book3_to_book_tag3_book3_id_index\` on \`book3_to_book_tag3\` (\`book3_id\`);
+create index \`book3_to_book_tag3_book_tag3_id_index\` on \`book3_to_book_tag3\` (\`book_tag3_id\`);
+
+alter table \`publisher3_to_test3\` add column \`publisher3_id\` integer null;
+alter table \`publisher3_to_test3\` add column \`test3_id\` integer null;
+create index \`publisher3_to_test3_publisher3_id_index\` on \`publisher3_to_test3\` (\`publisher3_id\`);
+create index \`publisher3_to_test3_test3_id_index\` on \`publisher3_to_test3\` (\`test3_id\`);
+
+pragma foreign_keys = on;
+"
+`;
+
+exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-drop-schema-dump 1`] = `
+"pragma foreign_keys = off;
+
+drop table if exists \`author3\`;
+drop table if exists \`book3\`;
+drop table if exists \`book_tag3\`;
+drop table if exists \`publisher3\`;
+drop table if exists \`test3\`;
+drop table if exists \`book3_to_book_tag3\`;
+drop table if exists \`publisher3_to_test3\`;
+
+pragma foreign_keys = on;
 "
 `;
 

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -15,7 +15,7 @@ const { BaseEntity4, Author3, Book3, BookTag3, Publisher3, Test3 } = require('./
 export const BASE_DIR = __dirname;
 export const TEMP_DIR = process.cwd() + '/temp';
 
-export async function initORM() {
+export async function initORMMongo() {
   let hash = '';
 
   if (process.env.ORM_PARALLEL) {

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -1,148 +1,65 @@
-SET NAMES utf8;
-SET FOREIGN_KEY_CHECKS=0;
+set names utf8;
+set foreign_key_checks = 0;
 
+drop table if exists `author2`;
+drop table if exists `book2`;
+drop table if exists `book_tag2`;
+drop table if exists `publisher2`;
+drop table if exists `test2`;
+drop table if exists `foo_bar2`;
+drop table if exists `foo_baz2`;
+drop table if exists `book2_to_book_tag2`;
+drop table if exists `publisher2_to_test2`;
 
-DROP TABLE IF EXISTS `author2`;
+create table `author2` (`id` int unsigned not null auto_increment primary key, `created_at` datetime(3) not null default current_timestamp(3), `updated_at` datetime(3) not null default current_timestamp(3), `name` varchar(255) not null, `email` varchar(255) not null, `age` int(11) null, `terms_accepted` tinyint(1) not null default 0, `identities` json null, `born` datetime null, `favourite_book_uuid_pk` varchar(36) null, `favourite_author_id` int(11) unsigned null) default character set utf8 engine = InnoDB;
+alter table `author2` add unique `author2_email_unique`(`email`);
+alter table `author2` add index `author2_favourite_book_uuid_pk_index`(`favourite_book_uuid_pk`);
+alter table `author2` add index `author2_favourite_author_id_index`(`favourite_author_id`);
 
-CREATE TABLE `author2` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  `name` varchar(255) NOT NULL,
-  `email` varchar(255) UNIQUE NOT NULL,
-  `age` int(11) DEFAULT NULL,
-  `terms_accepted` tinyint(1) DEFAULT 0,
-  `identities` json DEFAULT NULL,
-  `born` datetime DEFAULT NULL,
-  `favourite_book_uuid_pk` varchar(36) DEFAULT NULL,
-  `favourite_author_id` int(11) unsigned DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `favourite_book_uuid_pk` (`favourite_book_uuid_pk`),
-  KEY `favourite_author_id` (`favourite_author_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+create table `book2` (`uuid_pk` varchar(36) not null, `created_at` datetime(3) not null default current_timestamp(3), `title` varchar(255) null, `perex` text null, `price` float null, `double` double null, `meta` json null, `author_id` int(11) unsigned null, `publisher_id` int(11) unsigned null, `foo` varchar(255) null) default character set utf8 engine = InnoDB;
+alter table `book2` add primary key `book2_pkey`(`uuid_pk`);
+alter table `book2` add index `book2_author_id_index`(`author_id`);
+alter table `book2` add index `book2_publisher_id_index`(`publisher_id`);
 
+create table `book_tag2` (`id` int unsigned not null auto_increment primary key, `name` varchar(50) not null) default character set utf8 engine = InnoDB;
 
-DROP TABLE IF EXISTS `book2`;
+create table `publisher2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `type` varchar(10) not null) default character set utf8 engine = InnoDB;
 
-CREATE TABLE `book2` (
-  `uuid_pk` varchar(36) NOT NULL,
-  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  `title` varchar(255) DEFAULT NULL,
-  `perex` text DEFAULT NULL,
-  `price` float DEFAULT NULL,
-  `double` double DEFAULT NULL,
-  `meta` json DEFAULT NULL,
-  `author_id` int(11) unsigned DEFAULT NULL,
-  `publisher_id` int(11) unsigned DEFAULT NULL,
-  `foo` varchar(255) DEFAULT NULL,
-  PRIMARY KEY (`uuid_pk`),
-  KEY `author_id` (`author_id`),
-  KEY `publisher_id` (`publisher_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+create table `test2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) null, `book_uuid_pk` varchar(36) null, `version` int(11) not null default 1) default character set utf8 engine = InnoDB;
+alter table `test2` add unique `test2_book_uuid_pk_unique`(`book_uuid_pk`);
+alter table `test2` add index `test2_book_uuid_pk_index`(`book_uuid_pk`);
 
+create table `foo_bar2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `baz_id` int(11) unsigned null, `foo_bar_id` int(11) unsigned null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+alter table `foo_bar2` add unique `foo_bar2_baz_id_unique`(`baz_id`);
+alter table `foo_bar2` add index `foo_bar2_baz_id_index`(`baz_id`);
+alter table `foo_bar2` add unique `foo_bar2_foo_bar_id_unique`(`foo_bar_id`);
+alter table `foo_bar2` add index `foo_bar2_foo_bar_id_index`(`foo_bar_id`);
 
-DROP TABLE IF EXISTS `book_tag2`;
+create table `foo_baz2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null) default character set utf8 engine = InnoDB;
 
-CREATE TABLE `book_tag2` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(50) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+create table `book2_to_book_tag2` (`id` int unsigned not null auto_increment primary key, `book2_uuid_pk` varchar(36) not null, `book_tag2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table `book2_to_book_tag2` add index `book2_to_book_tag2_book2_uuid_pk_index`(`book2_uuid_pk`);
+alter table `book2_to_book_tag2` add index `book2_to_book_tag2_book_tag2_id_index`(`book_tag2_id`);
 
+create table `publisher2_to_test2` (`id` int unsigned not null auto_increment primary key, `publisher2_id` int(11) unsigned not null, `test2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
+alter table `publisher2_to_test2` add index `publisher2_to_test2_publisher2_id_index`(`publisher2_id`);
+alter table `publisher2_to_test2` add index `publisher2_to_test2_test2_id_index`(`test2_id`);
 
-DROP TABLE IF EXISTS `publisher2`;
+alter table `author2` add constraint `author2_favourite_book_uuid_pk_foreign` foreign key (`favourite_book_uuid_pk`) references `book2` (`uuid_pk`) on update cascade on delete set null;
+alter table `author2` add constraint `author2_favourite_author_id_foreign` foreign key (`favourite_author_id`) references `author2` (`id`) on update cascade on delete set null;
 
-CREATE TABLE `publisher2` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `type` varchar(10) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+alter table `book2` add constraint `book2_author_id_foreign` foreign key (`author_id`) references `author2` (`id`) on delete set null;
+alter table `book2` add constraint `book2_publisher_id_foreign` foreign key (`publisher_id`) references `publisher2` (`id`) on delete set null;
 
+alter table `test2` add constraint `test2_book_uuid_pk_foreign` foreign key (`book_uuid_pk`) references `book2` (`uuid_pk`) on delete set null;
 
-DROP TABLE IF EXISTS `test2`;
+alter table `foo_bar2` add constraint `foo_bar2_baz_id_foreign` foreign key (`baz_id`) references `foo_baz2` (`id`) on update cascade on delete set null;
+alter table `foo_bar2` add constraint `foo_bar2_foo_bar_id_foreign` foreign key (`foo_bar_id`) references `foo_bar2` (`id`) on update cascade on delete set null;
 
-CREATE TABLE `test2` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) DEFAULT NULL,
-  `book_uuid_pk` varchar(36) UNIQUE DEFAULT NULL,
-  `version` int(11) NOT NULL DEFAULT 1,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+alter table `book2_to_book_tag2` add constraint `book2_to_book_tag2_book2_uuid_pk_foreign` foreign key (`book2_uuid_pk`) references `book2` (`uuid_pk`) on update cascade on delete cascade;
+alter table `book2_to_book_tag2` add constraint `book2_to_book_tag2_book_tag2_id_foreign` foreign key (`book_tag2_id`) references `book_tag2` (`id`) on update cascade on delete cascade;
 
+alter table `publisher2_to_test2` add constraint `publisher2_to_test2_publisher2_id_foreign` foreign key (`publisher2_id`) references `publisher2` (`id`) on update cascade on delete cascade;
+alter table `publisher2_to_test2` add constraint `publisher2_to_test2_test2_id_foreign` foreign key (`test2_id`) references `test2` (`id`) on update cascade on delete cascade;
 
-DROP TABLE IF EXISTS `foo_bar2`;
-
-CREATE TABLE `foo_bar2` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `baz_id` int(11) unsigned UNIQUE DEFAULT NULL,
-  `foo_bar_id` int(11) unsigned UNIQUE DEFAULT NULL,
-  `version` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-DROP TABLE IF EXISTS `foo_baz2`;
-
-CREATE TABLE `foo_baz2` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-DROP TABLE IF EXISTS `book2_to_book_tag2`;
-
-CREATE TABLE `book2_to_book_tag2` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `book2_uuid_pk` varchar(36) NOT NULL,
-  `book_tag2_id` int(11) unsigned NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `book2_uuid_pk` (`book2_uuid_pk`),
-  KEY `book_tag2_id` (`book_tag2_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-DROP TABLE IF EXISTS `publisher2_to_test2`;
-
-CREATE TABLE `publisher2_to_test2` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `publisher2_id` int(11) unsigned NOT NULL,
-  `test2_id` int(11) unsigned NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `publisher2_id` (`publisher2_id`),
-  KEY `test2_id` (`test2_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-ALTER TABLE `author2`
-  ADD CONSTRAINT `author2_ibfk_1` FOREIGN KEY (`favourite_book_uuid_pk`) REFERENCES `book2` (`uuid_pk`) ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT `author2_ibfk_2` FOREIGN KEY (`favourite_author_id`) REFERENCES `author2` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
-
-
-ALTER TABLE `book2`
-  ADD CONSTRAINT `book2_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `author2` (`id`) ON DELETE SET NULL,
-  ADD CONSTRAINT `book2_ibfk_2` FOREIGN KEY (`publisher_id`) REFERENCES `publisher2` (`id`) ON DELETE SET NULL;
-
-
-ALTER TABLE `test2`
-  ADD CONSTRAINT `test2_ibfk_1` FOREIGN KEY (`book_uuid_pk`) REFERENCES `book2` (`uuid_pk`) ON DELETE SET NULL;
-
-
-ALTER TABLE `foo_bar2`
-  ADD CONSTRAINT `foo_bar2_ibfk_1` FOREIGN KEY (`baz_id`) REFERENCES `foo_baz2` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT `foo_bar2_ibfk_2` FOREIGN KEY (`foo_bar_id`) REFERENCES `foo_bar2` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
-
-
-ALTER TABLE `book2_to_book_tag2`
-  ADD CONSTRAINT `book2_to_book_tag2_ibfk_1` FOREIGN KEY (`book2_uuid_pk`) REFERENCES `book2` (`uuid_pk`) ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT `book2_to_book_tag2_ibfk_2` FOREIGN KEY (`book_tag2_id`) REFERENCES `book_tag2` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
-
-ALTER TABLE `publisher2_to_test2`
-  ADD CONSTRAINT `publisher2_to_test2_ibfk_1` FOREIGN KEY (`publisher2_id`) REFERENCES `publisher2` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT `publisher2_to_test2_ibfk_2` FOREIGN KEY (`test2_id`) REFERENCES `test2` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
-
-SET FOREIGN_KEY_CHECKS=1;
+set foreign_key_checks = 1;

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -1,157 +1,54 @@
-SET NAMES 'utf8';
-SET session_replication_role = 'replica';
+set names 'utf8';
+set session_replication_role = 'replica';
 
+drop table if exists "author2" cascade;
+drop table if exists "book2" cascade;
+drop table if exists "book_tag2" cascade;
+drop table if exists "publisher2" cascade;
+drop table if exists "test2" cascade;
+drop table if exists "foo_bar2" cascade;
+drop table if exists "foo_baz2" cascade;
+drop table if exists "book2_to_book_tag2" cascade;
+drop table if exists "publisher2_to_test2" cascade;
 
-DROP TABLE IF EXISTS "author2" CASCADE;
-DROP SEQUENCE IF EXISTS "author2_seq";
+create table "author2" ("id" serial primary key, "created_at" timestamp(3) not null default current_timestamp(3), "updated_at" timestamp(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null, "terms_accepted" boolean not null default false, "identities" json null, "born" timestamp null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int null);
+alter table "author2" add constraint "author2_email_unique" unique ("email");
 
-CREATE SEQUENCE "author2_seq";
-CREATE TABLE "author2" (
-  "id" int check ("id" > 0) NOT NULL DEFAULT NEXTVAL('author2_seq'),
-  "created_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  "updated_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  "name" varchar(255) NOT NULL,
-  "email" varchar(255) UNIQUE NOT NULL,
-  "age" int DEFAULT NULL,
-  "terms_accepted" boolean NOT NULL DEFAULT false,
-  "identities" json DEFAULT NULL,
-  "born" timestamp DEFAULT NULL,
-  "favourite_book_uuid_pk" varchar(36) DEFAULT NULL,
-  "favourite_author_id" int check ("favourite_author_id" > 0) DEFAULT NULL,
-  PRIMARY KEY ("id")
-);
+create table "book2" ("uuid_pk" varchar(36) not null, "created_at" timestamp(3) not null default current_timestamp(3), "title" varchar(255) null, "perex" text null, "price" float null, "double" double precision null, "meta" json null, "author_id" int null, "publisher_id" int null, "foo" varchar(255) null);
+alter table "book2" add constraint "book2_pkey" primary key ("uuid_pk");
 
+create table "book_tag2" ("id" serial primary key, "name" varchar(50) not null);
 
-DROP TABLE IF EXISTS "book2" CASCADE;
-DROP SEQUENCE IF EXISTS "book2_seq";
+create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" varchar(10) not null);
 
-CREATE TABLE "book2" (
-  "uuid_pk" varchar(36) NOT NULL,
-  "created_at" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  "title" varchar(255) DEFAULT NULL,
-  "perex" text DEFAULT NULL,
-  "price" float DEFAULT NULL,
-  "double" double precision DEFAULT NULL,
-  "meta" json DEFAULT NULL,
-  "foo" varchar(255) DEFAULT NULL,
-  "author_id" int check ("author_id" > 0) DEFAULT NULL,
-  "publisher_id" int check ("publisher_id" > 0) DEFAULT NULL,
-  PRIMARY KEY ("uuid_pk")
-);
+create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" varchar(36) null, "version" int not null default 1);
+alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");
 
+create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "baz_id" int null, "foo_bar_id" int null, "version" timestamp(3) not null default current_timestamp(3));
+alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");
+alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");
 
-DROP TABLE IF EXISTS "book_tag2" CASCADE;
-DROP SEQUENCE IF EXISTS "book_tag2_seq";
+create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null);
 
-CREATE SEQUENCE "book_tag2_seq";
-CREATE TABLE "book_tag2" (
-  "id" int check ("id" > 0) NOT NULL DEFAULT NEXTVAL('book_tag2_seq'),
-  "name" varchar(50) NOT NULL,
-  PRIMARY KEY ("id")
-);
+create table "book2_to_book_tag2" ("id" serial primary key, "book2_uuid_pk" varchar(36) not null, "book_tag2_id" int not null);
 
+create table "publisher2_to_test2" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);
 
-DROP TABLE IF EXISTS "publisher2" CASCADE;
-DROP SEQUENCE IF EXISTS "publisher2_seq";
+alter table "author2" add constraint "author2_favourite_book_uuid_pk_foreign" foreign key ("favourite_book_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete set null;
+alter table "author2" add constraint "author2_favourite_author_id_foreign" foreign key ("favourite_author_id") references "author2" ("id") on update cascade on delete set null;
 
-CREATE SEQUENCE "publisher2_seq";
-CREATE TABLE "publisher2" (
-  "id" int check ("id" > 0) NOT NULL DEFAULT NEXTVAL('publisher2_seq'),
-  "name" varchar(255) NOT NULL,
-  "type" varchar(10) NOT NULL,
-  PRIMARY KEY ("id")
-);
+alter table "book2" add constraint "book2_author_id_foreign" foreign key ("author_id") references "author2" ("id") on delete set null;
+alter table "book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "publisher2" ("id") on delete set null;
 
+alter table "test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "book2" ("uuid_pk") on delete set null;
 
-DROP TABLE IF EXISTS "test2" CASCADE;
-DROP SEQUENCE IF EXISTS "test2_seq";
+alter table "foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "foo_baz2" ("id") on update cascade on delete set null;
+alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_foreign" foreign key ("foo_bar_id") references "foo_bar2" ("id") on update cascade on delete set null;
 
-CREATE SEQUENCE "test2_seq";
-CREATE TABLE "test2" (
-  "id" int check ("id" > 0) NOT NULL DEFAULT NEXTVAL('test2_seq'),
-  "name" varchar(255) DEFAULT NULL,
-  "book_uuid_pk" varchar(36) UNIQUE DEFAULT NULL,
-  "version" int NOT NULL DEFAULT 1,
-  PRIMARY KEY ("id")
-);
+alter table "book2_to_book_tag2" add constraint "book2_to_book_tag2_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete cascade;
+alter table "book2_to_book_tag2" add constraint "book2_to_book_tag2_book_tag2_id_foreign" foreign key ("book_tag2_id") references "book_tag2" ("id") on update cascade on delete cascade;
 
+alter table "publisher2_to_test2" add constraint "publisher2_to_test2_publisher2_id_foreign" foreign key ("publisher2_id") references "publisher2" ("id") on update cascade on delete cascade;
+alter table "publisher2_to_test2" add constraint "publisher2_to_test2_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
 
-DROP TABLE IF EXISTS "foo_bar2" CASCADE;
-DROP SEQUENCE IF EXISTS "foo_bar2_seq";
-
-CREATE SEQUENCE "foo_bar2_seq";
-CREATE TABLE "foo_bar2" (
-  "id" int check ("id" > 0) NOT NULL DEFAULT NEXTVAL('foo_bar2_seq'),
-  "name" varchar(255) NOT NULL,
-  "baz_id" int check ("baz_id" > 0) UNIQUE DEFAULT NULL,
-  "foo_bar_id" int check ("foo_bar_id" > 0) UNIQUE DEFAULT NULL,
-  "version" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  PRIMARY KEY ("id")
-);
-
-
-DROP TABLE IF EXISTS "foo_baz2" CASCADE;
-DROP SEQUENCE IF EXISTS "foo_baz2_seq";
-
-CREATE SEQUENCE "foo_baz2_seq";
-CREATE TABLE "foo_baz2" (
-  "id" int check ("id" > 0) NOT NULL DEFAULT NEXTVAL('foo_baz2_seq'),
-  "name" varchar(255) NOT NULL,
-  PRIMARY KEY ("id")
-);
-
-
-DROP TABLE IF EXISTS "book2_to_book_tag2" CASCADE;
-DROP SEQUENCE IF EXISTS "book2_to_book_tag2_seq";
-
-CREATE SEQUENCE "book2_to_book_tag2_seq";
-CREATE TABLE "book2_to_book_tag2" (
-  "id" int check ("id" > 0) NOT NULL DEFAULT NEXTVAL('book2_to_book_tag2_seq'),
-  "book2_uuid_pk" varchar(36) NOT NULL,
-  "book_tag2_id" int check ("book_tag2_id" > 0) NOT NULL,
-  PRIMARY KEY ("id")
-);
-
-
-DROP TABLE IF EXISTS "publisher2_to_test2" CASCADE;
-DROP SEQUENCE IF EXISTS "publisher2_to_test2_seq";
-
-CREATE SEQUENCE "publisher2_to_test2_seq";
-CREATE TABLE "publisher2_to_test2" (
-  "id" int check ("id" > 0) NOT NULL DEFAULT NEXTVAL('publisher2_to_test2_seq'),
-  "publisher2_id" int check ("publisher2_id" > 0) NOT NULL,
-  "test2_id" int check ("test2_id" > 0) NOT NULL,
-  PRIMARY KEY ("id")
-);
-
-
-ALTER TABLE "author2"
-  ADD CONSTRAINT "author2_ibfk_1" FOREIGN KEY ("favourite_book_uuid_pk") REFERENCES "book2" ("uuid_pk") ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT "author2_ibfk_2" FOREIGN KEY ("favourite_author_id") REFERENCES "author2" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
-
-ALTER TABLE "book2"
-  ADD CONSTRAINT "book2_ibfk_1" FOREIGN KEY ("author_id") REFERENCES "author2" ("id") ON DELETE SET NULL,
-  ADD CONSTRAINT "book2_ibfk_2" FOREIGN KEY ("publisher_id") REFERENCES "publisher2" ("id") ON DELETE SET NULL;
-
-
-ALTER TABLE "test2"
-  ADD CONSTRAINT "test2_ibfk_1" FOREIGN KEY ("book_uuid_pk") REFERENCES "book2" ("uuid_pk") ON DELETE SET NULL;
-
-
-ALTER TABLE "foo_bar2"
-  ADD CONSTRAINT "foo_bar2_ibfk_1" FOREIGN KEY ("baz_id") REFERENCES "foo_baz2" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
-  ADD CONSTRAINT "foo_bar2_ibfk_2" FOREIGN KEY ("foo_bar_id") REFERENCES "foo_bar2" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
-
-ALTER TABLE "book2_to_book_tag2"
-  ADD CONSTRAINT "book2_to_book_tag2_ibfk_1" FOREIGN KEY ("book2_uuid_pk") REFERENCES "book2" ("uuid_pk") ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT "book2_to_book_tag2_ibfk_2" FOREIGN KEY ("book_tag2_id") REFERENCES "book_tag2" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
-
-ALTER TABLE "publisher2_to_test2"
-  ADD CONSTRAINT "publisher2_to_test2_ibfk_1" FOREIGN KEY ("publisher2_id") REFERENCES "publisher2" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT "publisher2_to_test2_ibfk_2" FOREIGN KEY ("test2_id") REFERENCES "test2" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
-
-SET session_replication_role = 'origin';
+set session_replication_role = 'origin';

--- a/tests/sqlite-schema.sql
+++ b/tests/sqlite-schema.sql
@@ -1,80 +1,44 @@
-PRAGMA foreign_keys=OFF;
+pragma foreign_keys = off;
 
+drop table if exists `author3`;
+drop table if exists `book3`;
+drop table if exists `book_tag3`;
+drop table if exists `publisher3`;
+drop table if exists `test3`;
+drop table if exists `book3_to_book_tag3`;
+drop table if exists `publisher3_to_test3`;
 
-DROP TABLE IF EXISTS "author3";
+create table `author3` (`id` integer not null primary key autoincrement, `created_at` text null, `updated_at` text null, `name` text not null, `email` text not null, `age` integer null, `terms_accepted` integer not null default 0, `identities` text null, `born` text null);
+create unique index `author3_email_unique` on `author3` (`email`);
 
-CREATE TABLE "author3" (
-  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-  "created_at" TEXT DEFAULT NULL,
-  "updated_at" TEXT DEFAULT NULL,
-  "name" TEXT NOT NULL,
-  "email" TEXT UNIQUE NOT NULL,
-  "age" INTEGER DEFAULT NULL,
-  "terms_accepted" INTEGER DEFAULT 0,
-  "identities" TEXT DEFAULT NULL,
-  "born" TEXT DEFAULT NULL
-);
+create table `book3` (`id` integer not null primary key autoincrement, `title` text not null, `foo` text null);
 
+create table `book_tag3` (`id` integer not null primary key autoincrement, `name` text not null, `version` text not null default current_timestamp);
 
-DROP TABLE IF EXISTS "book3";
+create table `publisher3` (`id` integer not null primary key autoincrement, `name` text not null, `type` text not null);
 
-CREATE TABLE "book3" (
-  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-  "title" TEXT NOT NULL,
-  "foo" TEXT DEFAULT NULL
-);
+create table `test3` (`id` integer not null primary key autoincrement, `name` text null, `version` integer not null default 1);
 
+create table `book3_to_book_tag3` (`id` integer not null primary key autoincrement);
 
-DROP TABLE IF EXISTS "book_tag3";
+create table `publisher3_to_test3` (`id` integer not null primary key autoincrement);
 
-CREATE TABLE "book_tag3" (
-  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-  "name" TEXT NOT NULL,
-  "version" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
+alter table `author3` add column `favourite_book_id` integer null references `book3` (`id`) on delete set null on update cascade;
+create index `author3_favourite_book_id_index` on `author3` (`favourite_book_id`);
 
+alter table `book3` add column `author_id` integer null references `author3` (`id`) on delete set null on update cascade;
+alter table `book3` add column `publisher_id` integer null references `publisher3` (`id`) on delete set null on update cascade;
+create index `book3_author_id_index` on `book3` (`author_id`);
+create index `book3_publisher_id_index` on `book3` (`publisher_id`);
 
-DROP TABLE IF EXISTS "publisher3";
+alter table `book3_to_book_tag3` add column `book3_id` integer null references `book3` (`id`) on delete cascade on update cascade;
+alter table `book3_to_book_tag3` add column `book_tag3_id` integer null references `book_tag3` (`id`) on delete cascade on update cascade;
+create index `book3_to_book_tag3_book3_id_index` on `book3_to_book_tag3` (`book3_id`);
+create index `book3_to_book_tag3_book_tag3_id_index` on `book3_to_book_tag3` (`book_tag3_id`);
 
-CREATE TABLE "publisher3" (
-  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-  "name" TEXT NOT NULL,
-  "type" TEXT NOT NULL
-);
+alter table `publisher3_to_test3` add column `publisher3_id` integer null references `publisher3` (`id`) on delete cascade on update cascade;
+alter table `publisher3_to_test3` add column `test3_id` integer null references `test3` (`id`) on delete cascade on update cascade;
+create index `publisher3_to_test3_publisher3_id_index` on `publisher3_to_test3` (`publisher3_id`);
+create index `publisher3_to_test3_test3_id_index` on `publisher3_to_test3` (`test3_id`);
 
-
-DROP TABLE IF EXISTS "test3";
-
-CREATE TABLE "test3" (
-  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-  "name" TEXT DEFAULT NULL,
-  "version" INTEGER NOT NULL DEFAULT 1
-);
-
-
-DROP TABLE IF EXISTS "book3_to_book_tag3";
-
-CREATE TABLE "book3_to_book_tag3" (
-  "id" INTEGER PRIMARY KEY AUTOINCREMENT
-);
-
-
-DROP TABLE IF EXISTS "publisher3_to_test3";
-
-CREATE TABLE "publisher3_to_test3" (
-  "id" INTEGER PRIMARY KEY AUTOINCREMENT
-);
-
-
-ALTER TABLE "author3" ADD "favourite_book_id" INTEGER DEFAULT NULL REFERENCES "book3" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
-ALTER TABLE "book3" ADD "author_id" INTEGER DEFAULT NULL REFERENCES "author3" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "book3" ADD "publisher_id" INTEGER DEFAULT NULL REFERENCES "publisher3" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
-ALTER TABLE "book3_to_book_tag3" ADD "book3_id" INTEGER DEFAULT NULL REFERENCES "book3" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
-ALTER TABLE "book3_to_book_tag3" ADD "book_tag3_id" INTEGER DEFAULT NULL REFERENCES "book_tag3" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
-ALTER TABLE "publisher3_to_test3" ADD "publisher3_id" INTEGER DEFAULT NULL REFERENCES "publisher3" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
-ALTER TABLE "publisher3_to_test3" ADD "test3_id" INTEGER DEFAULT NULL REFERENCES "test3" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
-PRAGMA foreign_keys=ON;
+pragma foreign_keys = on;


### PR DESCRIPTION
SchemaGenerator now offers `createSchema` and `dropSchema` methods that by default return the necessary SQL, as well as with a `run` flag enabled it can run the SQL directly.

There is also `SchemaGenerator.execute()` that breaks the query into separate lines and executes it on current connection. This method is used under the hood when using the `run` flag. 

**BREAKING CHANGES:**
`SchemaGenerator.generate()` is now async.