### PR TITLE
feat(mapping): allow overriding getClassName() in NamingStrategy

### DIFF
--- a/lib/metadata/MetadataDiscovery.ts
+++ b/lib/metadata/MetadataDiscovery.ts
@@ -73,7 +73,7 @@ export class MetadataDiscovery {
         continue;
       }
 
-      const name = this.getClassName(file);
+      const name = this.namingStrategy.getClassName(file);
       const path = Utils.normalizePath(this.config.get('baseDir'), basePath, file);
       const target = require(path)[name]; // include the file to trigger loading of metadata
       await this.discoverEntity(target, path);
@@ -268,13 +268,6 @@ export class MetadataDiscovery {
     }
 
     return ret;
-  }
-
-  private getClassName(file: string): string {
-    const name = file.split('.')[0];
-    const ret = name.replace(/-(\w)/, m => m[1].toUpperCase());
-
-    return ret.charAt(0).toUpperCase() + ret.slice(1);
   }
 
   private defineBaseEntityProperties(meta: EntityMetadata): void {

--- a/lib/naming-strategy/AbstractNamingStrategy.ts
+++ b/lib/naming-strategy/AbstractNamingStrategy.ts
@@ -1,0 +1,19 @@
+import { NamingStrategy } from './NamingStrategy';
+
+export abstract class AbstractNamingStrategy implements NamingStrategy {
+
+  getClassName(file: string): string {
+    const name = file.split('.')[0];
+    const ret = name.replace(/-(\w)/, m => m[1].toUpperCase());
+
+    return ret.charAt(0).toUpperCase() + ret.slice(1);
+  }
+
+  abstract classToTableName(entityName: string): string;
+  abstract joinColumnName(propertyName: string): string;
+  abstract joinKeyColumnName(entityName: string, referencedColumnName?: string): string;
+  abstract joinTableName(sourceEntity: string, targetEntity: string, propertyName?: string): string;
+  abstract propertyToColumnName(propertyName: string): string;
+  abstract referenceColumnName(): string;
+
+}

--- a/lib/naming-strategy/MongoNamingStrategy.ts
+++ b/lib/naming-strategy/MongoNamingStrategy.ts
@@ -1,6 +1,6 @@
-import { NamingStrategy } from './NamingStrategy';
+import { AbstractNamingStrategy } from './AbstractNamingStrategy';
 
-export class MongoNamingStrategy implements NamingStrategy {
+export class MongoNamingStrategy extends AbstractNamingStrategy {
 
   classToTableName(entityName: string): string {
     return entityName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();

--- a/lib/naming-strategy/NamingStrategy.ts
+++ b/lib/naming-strategy/NamingStrategy.ts
@@ -1,6 +1,11 @@
 export interface NamingStrategy {
 
   /**
+   * Return a name of the class based on its file name
+   */
+  getClassName(file: string): string;
+
+  /**
    * Return a table name for an entity class
    */
   classToTableName(entityName: string): string;

--- a/lib/naming-strategy/UnderscoreNamingStrategy.ts
+++ b/lib/naming-strategy/UnderscoreNamingStrategy.ts
@@ -1,6 +1,6 @@
-import { NamingStrategy } from './NamingStrategy';
+import { AbstractNamingStrategy } from './AbstractNamingStrategy';
 
-export class UnderscoreNamingStrategy implements NamingStrategy {
+export class UnderscoreNamingStrategy extends AbstractNamingStrategy {
 
   classToTableName(entityName: string): string {
     return this.underscore(entityName);

--- a/lib/naming-strategy/index.ts
+++ b/lib/naming-strategy/index.ts
@@ -1,3 +1,4 @@
 export * from './NamingStrategy';
+export * from './AbstractNamingStrategy';
 export * from './MongoNamingStrategy';
 export * from './UnderscoreNamingStrategy';


### PR DESCRIPTION
getClassName() is used to find entity class name based on its file name. Now users can override the default implementation to accommodate their specific needs.

Closes #15