### PR TITLE
feat(metadata): create instance of metadata instead of using static one

### DIFF
--- a/lib/connections/Connection.ts
+++ b/lib/connections/Connection.ts
@@ -6,7 +6,7 @@ import { MetadataStorage } from '../metadata';
 export abstract class Connection {
 
   protected readonly logger = this.config.getLogger();
-  protected readonly metadata = MetadataStorage.getMetadata();
+  protected metadata: MetadataStorage;
   protected abstract client: any;
 
   constructor(protected readonly config: Configuration) { }
@@ -54,6 +54,10 @@ export abstract class Connection {
     const url = new URL(this.config.getClientUrl(true));
 
     return `${url.protocol}//${options.user}${options.password ? ':*****' : ''}@${options.host}:${options.port}`;
+  }
+
+  setMetadata(metadata: MetadataStorage): void {
+    this.metadata = metadata;
   }
 
   protected async executeQuery<T>(query: string, params: any[], cb: () => Promise<T>): Promise<T> {

--- a/lib/connections/MongoConnection.ts
+++ b/lib/connections/MongoConnection.ts
@@ -180,7 +180,9 @@ export class MongoConnection extends Connection {
 
   private getCollectionName(name: EntityName<IEntity>): string {
     name = Utils.className(name);
-    return this.metadata[name] ? this.metadata[name].collection : name;
+    const meta = this.metadata.get(name);
+
+    return meta ? meta.collection : name;
   }
 
 }

--- a/lib/drivers/IDatabaseDriver.ts
+++ b/lib/drivers/IDatabaseDriver.ts
@@ -3,6 +3,7 @@ import { Connection, QueryResult, Transaction } from '../connections';
 import { QueryOrderMap } from '../query';
 import { Platform } from '../platforms';
 import { LockMode } from '../unit-of-work';
+import { MetadataStorage } from '../metadata';
 
 export interface IDatabaseDriver<C extends Connection = Connection> {
 
@@ -36,6 +37,8 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   loadFromPivotTable<T extends IEntity>(prop: EntityProperty, owners: IPrimaryKey[], ctx?: Transaction): Promise<Record<string, T[]>>;
 
   getPlatform(): Platform;
+
+  setMetadata(metadata: MetadataStorage): void;
 
 }
 

--- a/lib/drivers/MongoDriver.ts
+++ b/lib/drivers/MongoDriver.ts
@@ -17,7 +17,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     where = this.renameFields(entityName, where);
     const res = await this.connection.find<T>(entityName, where, orderBy, limit, offset);
 
-    return res.map((r: T) => this.mapResult<T>(r, this.metadata[entityName])!);
+    return res.map((r: T) => this.mapResult<T>(r, this.metadata.get(entityName))!);
   }
 
   async findOne<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T> | IPrimaryKey, populate: string[] = [], orderBy: QueryOrderMap = {}, fields?: string[], lockMode?: LockMode): Promise<T | null> {
@@ -28,7 +28,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     where = this.renameFields(entityName, where) as FilterQuery<T>;
     const res = await this.connection.find<T>(entityName, where, orderBy, 1, undefined, fields);
 
-    return this.mapResult<T>(res[0], this.metadata[entityName]);
+    return this.mapResult<T>(res[0], this.metadata.get(entityName));
   }
 
   async count<T extends IEntityType<T>>(entityName: string, where: FilterQuery<T>): Promise<number> {
@@ -69,7 +69,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
   private renameFields(entityName: string, data: any): any {
     data = Object.assign({}, data); // copy first
     Utils.renameKey(data, 'id', '_id');
-    const meta = this.metadata[entityName];
+    const meta = this.metadata.get(entityName);
 
     Object.keys(data).forEach(k => {
       if (meta && meta.properties[k]) {

--- a/lib/entity/ArrayCollection.ts
+++ b/lib/entity/ArrayCollection.ts
@@ -1,5 +1,4 @@
 import { EntityProperty, IEntityType, IPrimaryKey } from '../decorators';
-import { MetadataStorage } from '../metadata';
 import { ReferenceType } from './enums';
 import { Collection } from './Collection';
 
@@ -23,7 +22,7 @@ export class ArrayCollection<T extends IEntityType<T>> {
 
   toArray(): Record<string, any>[] {
     return this.getItems().map(item => {
-      const meta = MetadataStorage.getMetadata(item.constructor.name);
+      const meta = this.owner.__em.getMetadata().get(item.constructor.name);
       const args = [...meta.toJsonParams.map(() => undefined), [this.property.name]];
 
       return item.toJSON(...args);
@@ -141,7 +140,7 @@ export class ArrayCollection<T extends IEntityType<T>> {
 
   protected get property() {
     if (!this._property) {
-      const meta = MetadataStorage.getMetadata(this.owner.constructor.name);
+      const meta = this.owner.__em.getMetadata().get(this.owner.constructor.name);
       const field = Object.keys(meta.properties).find(k => this.owner[k] === this);
       this._property = meta.properties[field!];
     }

--- a/lib/entity/EntityAssigner.ts
+++ b/lib/entity/EntityAssigner.ts
@@ -3,7 +3,6 @@ import { SCALAR_TYPES } from './EntityFactory';
 import { EntityManager } from '../EntityManager';
 import { EntityData, EntityProperty, IEntity, IEntityType } from '../decorators';
 import { Utils } from '../utils';
-import { MetadataStorage } from '../metadata';
 import { ReferenceType } from './enums';
 
 export class EntityAssigner {
@@ -11,7 +10,7 @@ export class EntityAssigner {
   static assign<T extends IEntityType<T>>(entity: T, data: EntityData<T>, options?: AssignOptions): void;
   static assign<T extends IEntityType<T>>(entity: T, data: EntityData<T>, onlyProperties?: boolean): void;
   static assign<T extends IEntityType<T>>(entity: T, data: EntityData<T>, onlyProperties: AssignOptions | boolean = false): void {
-    const meta = MetadataStorage.getMetadata(entity.constructor.name);
+    const meta = entity.__em.getMetadata().get(entity.constructor.name);
     const props = meta.properties;
     const options = (typeof onlyProperties === 'boolean' ? { onlyProperties } : onlyProperties);
 

--- a/lib/entity/EntityFactory.ts
+++ b/lib/entity/EntityFactory.ts
@@ -9,17 +9,17 @@ export const SCALAR_TYPES = ['string', 'number', 'boolean', 'Date'];
 
 export class EntityFactory {
 
-  private readonly metadata = MetadataStorage.getMetadata();
   private readonly hydrator = this.config.getHydrator(this);
 
   constructor(private readonly unitOfWork: UnitOfWork,
               private readonly driver: IDatabaseDriver,
-              private readonly config: Configuration) { }
+              private readonly config: Configuration,
+              private readonly metadata: MetadataStorage) { }
 
   create<T extends IEntityType<T>>(entityName: EntityName<T>, data: EntityData<T>, initialized = true): T {
     entityName = Utils.className(entityName);
     data = Object.assign({}, data);
-    const meta = this.metadata[entityName];
+    const meta = this.metadata.get(entityName);
     const platform = this.driver.getPlatform();
     const pk = platform.getSerializedPrimaryKeyField(meta.primaryKey);
 
@@ -64,7 +64,7 @@ export class EntityFactory {
 
   createReference<T extends IEntityType<T>>(entityName: EntityName<T>, id: IPrimaryKey): T {
     entityName = Utils.className(entityName);
-    const meta = this.metadata[entityName];
+    const meta = this.metadata.get(entityName);
 
     if (this.unitOfWork.getById(entityName, id)) {
       return this.unitOfWork.getById<T>(entityName, id);

--- a/lib/entity/EntityHelper.ts
+++ b/lib/entity/EntityHelper.ts
@@ -57,7 +57,7 @@ export class EntityHelper {
       __populated: { value: false, writable: true },
       __lazyInitialized: { value: false, writable: true },
       __entity: { value: true },
-      __em: { value: em },
+      __em: { value: em, writable: true },
       __uuid: {
         get(): string {
           if (!this.___uuid) {

--- a/lib/entity/EntityTransformer.ts
+++ b/lib/entity/EntityTransformer.ts
@@ -2,14 +2,13 @@ import { Utils } from '../utils';
 import { ArrayCollection } from './ArrayCollection';
 import { Collection } from './Collection';
 import { EntityData, EntityMetadata, IEntity, IEntityType } from '../decorators';
-import { MetadataStorage } from '../metadata';
 
 export class EntityTransformer {
 
   static toObject<T extends IEntityType<T>>(entity: T, ignoreFields: string[] = []): EntityData<T> {
     const platform = entity.__em.getDriver().getPlatform();
     const pk = platform.getSerializedPrimaryKeyField(entity.__primaryKeyField);
-    const meta = MetadataStorage.getMetadata(entity.constructor.name);
+    const meta = entity.__em.getMetadata().get(entity.constructor.name);
     const pkProp = meta.properties[meta.primaryKey];
     const ret = (entity.__primaryKey && !pkProp.hidden ? { [pk]: platform.normalizePrimaryKey(entity.__primaryKey) } : {}) as EntityData<T>;
 
@@ -48,7 +47,7 @@ export class EntityTransformer {
     const platform = child.__em.getDriver().getPlatform();
 
     if (child.isInitialized() && child.__populated && child !== entity && !child.__lazyInitialized) {
-      const meta = MetadataStorage.getMetadata(child.constructor.name);
+      const meta = entity.__em.getMetadata().get(child.constructor.name);
       const args = [...meta.toJsonParams.map(() => undefined), ignoreFields];
 
       return child.toJSON(...args) as T[keyof T];

--- a/lib/metadata/MetadataDiscovery.ts
+++ b/lib/metadata/MetadataDiscovery.ts
@@ -2,27 +2,26 @@ import globby from 'globby';
 import { extname } from 'path';
 
 import { EntityClass, EntityClassGroup, EntityMetadata, EntityProperty, IEntityType } from '../decorators';
-import { EntityManager } from '../EntityManager';
 import { Configuration, Logger, Utils, ValidationError } from '../utils';
 import { MetadataValidator } from './MetadataValidator';
 import { MetadataStorage } from './MetadataStorage';
-import { Cascade, EntityHelper, ReferenceType } from '../entity';
+import { Cascade, ReferenceType } from '../entity';
+import { Platform } from '../platforms';
 
 export class MetadataDiscovery {
 
-  private readonly metadata = MetadataStorage.getMetadata();
   private readonly namingStrategy = this.config.getNamingStrategy();
   private readonly metadataProvider = this.config.getMetadataProvider();
   private readonly cache = this.config.getCacheAdapter();
-  private readonly platform = this.em.getDriver().getPlatform();
   private readonly validator = new MetadataValidator();
   private readonly discovered: EntityMetadata[] = [];
 
-  constructor(private readonly em: EntityManager,
+  constructor(private readonly metadata: MetadataStorage,
+              private readonly platform: Platform,
               private readonly config: Configuration,
               private readonly logger: Logger) { }
 
-  async discover(): Promise<Record<string, EntityMetadata>> {
+  async discover(): Promise<MetadataStorage> {
     const startTime = Date.now();
     this.logger.debug(`ORM entity discovery started`);
     this.discovered.length = 0;
@@ -49,10 +48,11 @@ export class MetadataDiscovery {
     const diff = Date.now() - startTime;
     this.logger.debug(`- entity discovery finished after ${diff} ms`);
 
-    const discovered: Record<string, EntityMetadata> = {};
+    const discovered = new MetadataStorage();
+
     this.discovered
       .filter(meta => meta.name)
-      .forEach(meta => discovered[meta.name] = meta );
+      .forEach(meta => discovered.set(meta.name, meta));
 
     return discovered;
   }
@@ -80,11 +80,24 @@ export class MetadataDiscovery {
     }
   }
 
+  private prepare<T extends IEntityType<T>>(entity: EntityClass<T> | EntityClassGroup<T>): EntityClass<T> {
+    // save path to entity from schema
+    if ('entity' in entity && 'schema' in entity) {
+      const schema = entity.schema;
+      const meta = this.metadata.get(entity.entity.name, true);
+      meta.path = schema.path;
+
+      return entity.entity;
+    }
+
+    return entity;
+  }
+
   private async discoverEntity<T extends IEntityType<T>>(entity: EntityClass<T> | EntityClassGroup<T>, path?: string): Promise<void> {
-    entity = this.metadataProvider.prepare(entity);
+    entity = this.prepare(entity);
     this.logger.debug(`- processing entity ${entity.name}`);
 
-    const meta = MetadataStorage.getMetadata(entity.name);
+    const meta = this.metadata.get(entity.name, true);
     meta.prototype = entity.prototype;
     meta.path = path || meta.path;
     meta.toJsonParams = Utils.getParamNames(entity.prototype.toJSON || '').filter(p => p !== '...args');
@@ -128,7 +141,7 @@ export class MetadataDiscovery {
     }
 
     if (prop.reference === ReferenceType.MANY_TO_ONE) {
-      const meta2 = this.metadata[prop.type];
+      const meta2 = this.metadata.get(prop.type);
       prop.inverseJoinColumn = meta2.properties[meta2.primaryKey].fieldName;
     }
 
@@ -148,7 +161,7 @@ export class MetadataDiscovery {
   }
 
   private initManyToOneFieldName(prop: EntityProperty, name: string): string {
-    const meta2 = this.metadata[prop.type];
+    const meta2 = this.metadata.get(prop.type);
     const referenceColumnName = meta2.properties[meta2.primaryKey].fieldName;
 
     return this.namingStrategy.joinKeyColumnName(name, referenceColumnName);
@@ -178,7 +191,7 @@ export class MetadataDiscovery {
     }
 
     if (prop.reference === ReferenceType.ONE_TO_ONE && !prop.inverseJoinColumn && prop.mappedBy) {
-      prop.inverseJoinColumn = this.metadata[prop.type].properties[prop.mappedBy].fieldName;
+      prop.inverseJoinColumn = this.metadata.get(prop.type).properties[prop.mappedBy].fieldName;
     }
 
     if (!prop.referenceColumnName) {
@@ -198,11 +211,6 @@ export class MetadataDiscovery {
       }
     });
     meta.serializedPrimaryKey = this.platform.getSerializedPrimaryKeyField(meta.primaryKey);
-
-    if (!Utils.isEntity(meta.prototype)) {
-      EntityHelper.decorate(meta, this.em);
-    }
-
     const ret: EntityMetadata[] = [];
 
     if (this.platform.usesPivotTable()) {
@@ -224,7 +232,7 @@ export class MetadataDiscovery {
       const primaryProp = { name: pk, type: 'number', reference: ReferenceType.SCALAR, primary: true, unsigned: true } as EntityProperty;
       this.initFieldName(primaryProp);
 
-      return this.metadata[prop.pivotTable] = {
+      return this.metadata.set(prop.pivotTable, {
         name: prop.pivotTable,
         collection: prop.pivotTable,
         primaryKey: pk,
@@ -233,7 +241,7 @@ export class MetadataDiscovery {
           [meta.name]: this.definePivotProperty(prop, meta.name, prop.type),
           [prop.type]: this.definePivotProperty(prop, prop.type, meta.name),
         },
-      } as EntityMetadata;
+      } as EntityMetadata);
     }
   }
 
@@ -241,7 +249,7 @@ export class MetadataDiscovery {
     const ret = { name, type: name, reference: ReferenceType.MANY_TO_ONE, cascade: [Cascade.ALL] } as EntityProperty;
 
     if (name === prop.type) {
-      const meta = this.metadata[name];
+      const meta = this.metadata.get(name);
       const prop2 = meta.properties[meta.primaryKey];
 
       if (!prop2.fieldName) {
@@ -265,7 +273,7 @@ export class MetadataDiscovery {
   }
 
   private defineBaseEntityProperties(meta: EntityMetadata): void {
-    const base = this.metadata[meta.extends];
+    const base = this.metadata.get(meta.extends);
 
     if (!meta.extends || !base) {
       return;
@@ -280,7 +288,7 @@ export class MetadataDiscovery {
   }
 
   private getDefaultVersionValue(prop: EntityProperty): any {
-    if (prop.default) {
+    if (typeof prop.default !== 'undefined') {
       return prop.default;
     }
 

--- a/lib/metadata/MetadataProvider.ts
+++ b/lib/metadata/MetadataProvider.ts
@@ -1,6 +1,5 @@
-import { EntityClass, EntityClassGroup, EntityMetadata, IEntityType } from '../decorators';
+import { EntityMetadata } from '../decorators';
 import { Configuration, Utils } from '../utils';
-import { MetadataStorage } from './MetadataStorage';
 
 export abstract class MetadataProvider {
 
@@ -10,19 +9,6 @@ export abstract class MetadataProvider {
 
   loadFromCache(meta: EntityMetadata, cache: EntityMetadata): void {
     Utils.merge(meta, cache);
-  }
-
-  prepare<T extends IEntityType<T>>(entity: EntityClass<T> | EntityClassGroup<T>): EntityClass<T> {
-    // save path to entity from schema
-    if ('entity' in entity && 'schema' in entity) {
-      const schema = entity.schema;
-      const meta = MetadataStorage.getMetadata(entity.entity.name);
-      meta.path = schema.path;
-
-      return entity.entity;
-    }
-
-    return entity;
   }
 
 }

--- a/lib/metadata/MetadataStorage.ts
+++ b/lib/metadata/MetadataStorage.ts
@@ -1,8 +1,16 @@
 import { EntityMetadata, IEntityType } from '../decorators';
+import { Utils } from '../utils';
+import { EntityManager } from '../EntityManager';
+import { EntityHelper } from '../entity';
 
 export class MetadataStorage {
 
   private static readonly metadata: Record<string, EntityMetadata> = {};
+  private readonly metadata: Record<string, EntityMetadata>;
+
+  constructor(metadata: Record<string, EntityMetadata> = {}) {
+    this.metadata = Utils.copy(metadata);
+  }
 
   static getMetadata(): Record<string, EntityMetadata>; // tslint:disable-next-line:lines-between-class-members
   static getMetadata<T extends IEntityType<T> = any>(entity: string): EntityMetadata<T>; // tslint:disable-next-line:lines-between-class-members
@@ -16,6 +24,36 @@ export class MetadataStorage {
     }
 
     return MetadataStorage.metadata;
+  }
+
+  static init(): MetadataStorage {
+    return new MetadataStorage(MetadataStorage.metadata);
+  }
+
+  getAll(): Record<string, EntityMetadata> {
+    return this.metadata;
+  }
+
+  get<T extends IEntityType<T> = any>(entity: string, init = false): EntityMetadata<T> {
+    if (!this.metadata[entity] && init) {
+      this.metadata[entity] = { properties: {} } as EntityMetadata;
+    }
+
+    return this.metadata[entity];
+  }
+
+  has(entity: string): boolean {
+    return entity in this.metadata;
+  }
+
+  set(entity: string, meta: EntityMetadata): EntityMetadata {
+    return this.metadata[entity] = meta;
+  }
+
+  decorate(em: EntityManager): void {
+    Object.values(this.metadata)
+      .filter(meta => meta.prototype && !Utils.isEntity(meta.prototype))
+      .forEach(meta => EntityHelper.decorate(meta, em));
   }
 
 }

--- a/lib/metadata/MetadataValidator.ts
+++ b/lib/metadata/MetadataValidator.ts
@@ -1,11 +1,12 @@
 import { EntityMetadata, EntityProperty } from '../decorators';
 import { ValidationError } from '../utils';
 import { ReferenceType } from '../entity';
+import { MetadataStorage } from './MetadataStorage';
 
 export class MetadataValidator {
 
-  validateEntityDefinition(metadata: Record<string, EntityMetadata>, name: string): void {
-    const meta = metadata[name];
+  validateEntityDefinition(metadata: MetadataStorage, name: string): void {
+    const meta = metadata.get(name);
 
     // entities have PK
     if (!meta.primaryKey) {
@@ -24,21 +25,21 @@ export class MetadataValidator {
     }
   }
 
-  private validateReference(meta: EntityMetadata, prop: EntityProperty, metadata: Record<string, EntityMetadata>): void {
+  private validateReference(meta: EntityMetadata, prop: EntityProperty, metadata: MetadataStorage): void {
     // references do have types
     if (!prop.type) {
       throw ValidationError.fromWrongTypeDefinition(meta, prop);
     }
 
     // references do have type of known entity
-    if (!metadata[prop.type]) {
+    if (!metadata.get(prop.type)) {
       throw ValidationError.fromWrongTypeDefinition(meta, prop);
     }
   }
 
-  private validateCollection(meta: EntityMetadata, prop: EntityProperty, metadata: Record<string, EntityMetadata>): void {
+  private validateCollection(meta: EntityMetadata, prop: EntityProperty, metadata: MetadataStorage): void {
     if (prop.reference === ReferenceType.ONE_TO_MANY) {
-      const owner = metadata[prop.type].properties[prop.mappedBy];
+      const owner = metadata.get(prop.type).properties[prop.mappedBy];
       return this.validateOneToManyInverseSide(meta, prop, owner);
     }
 
@@ -48,10 +49,10 @@ export class MetadataValidator {
     }
 
     if (prop.inversedBy) {
-      const inverse = metadata[prop.type].properties[prop.inversedBy];
+      const inverse = metadata.get(prop.type).properties[prop.inversedBy];
       this.validateManyToManyOwningSide(meta, prop, inverse);
     } else if (prop.mappedBy) {
-      const inverse = metadata[prop.type].properties[prop.mappedBy];
+      const inverse = metadata.get(prop.type).properties[prop.mappedBy];
       this.validateManyToManyInverseSide(meta, prop, inverse);
     }
   }

--- a/lib/unit-of-work/ChangeSetPersister.ts
+++ b/lib/unit-of-work/ChangeSetPersister.ts
@@ -8,13 +8,12 @@ import { ValidationError } from '../utils';
 
 export class ChangeSetPersister {
 
-  private readonly metadata = MetadataStorage.getMetadata();
-
   constructor(private readonly driver: IDatabaseDriver,
-              private readonly identifierMap: Record<string, EntityIdentifier>) { }
+              private readonly identifierMap: Record<string, EntityIdentifier>,
+              private readonly metadata: MetadataStorage) { }
 
   async persistToDatabase<T extends IEntityType<T>>(changeSet: ChangeSet<T>, ctx?: Transaction): Promise<void> {
-    const meta = this.metadata[changeSet.name];
+    const meta = this.metadata.get(changeSet.name);
 
     // process references first
     for (const prop of Object.values(meta.properties)) {

--- a/lib/utils/Configuration.ts
+++ b/lib/utils/Configuration.ts
@@ -1,10 +1,7 @@
 import { NamingStrategy } from '../naming-strategy';
 import { CacheAdapter, FileCacheAdapter, NullCacheAdapter } from '../cache';
-
-// we need to import this directly to fix circular deps
-import { TypeScriptMetadataProvider } from '../metadata/TypeScriptMetadataProvider';
+import { MetadataProvider, TypeScriptMetadataProvider } from '../metadata';
 import { EntityFactory, EntityRepository } from '../entity';
-import { MetadataProvider } from '../metadata';
 import { EntityClass, EntityClassGroup, EntityName, EntityOptions, IEntity } from '../decorators';
 import { Hydrator, ObjectHydrator } from '../hydration';
 import { Logger, Utils } from '../utils';

--- a/tests/EntityFactory.test.ts
+++ b/tests/EntityFactory.test.ts
@@ -3,8 +3,7 @@ import { Book, Author, Publisher } from './entities';
 import { MikroORM, Collection, Utils } from '../lib';
 import { EntityFactory, ReferenceType } from '../lib/entity';
 import { initORM, wipeDatabase } from './bootstrap';
-import { BaseEntity } from './entities/BaseEntity';
-import { MetadataDiscovery, MetadataStorage } from '../lib/metadata';
+import { MetadataDiscovery } from '../lib/metadata';
 
 describe('EntityFactory', () => {
 
@@ -13,16 +12,15 @@ describe('EntityFactory', () => {
 
   beforeAll(async () => {
     orm = await initORM();
-    await new MetadataDiscovery(orm.em, orm.config, orm.config.getLogger()).discover();
-    factory = new EntityFactory(orm.em.getUnitOfWork(), orm.em.getDriver(), orm.config);
+    await new MetadataDiscovery(orm.getMetadata(), orm.em.getDriver().getPlatform(), orm.config, orm.config.getLogger()).discover();
+    factory = new EntityFactory(orm.em.getUnitOfWork(), orm.em.getDriver(), orm.config, orm.getMetadata());
     expect(orm.em.config.getNamingStrategy().referenceColumnName()).toBe('_id');
   });
   beforeEach(async () => wipeDatabase(orm.em));
 
   test('should load entities', async () => {
-    const metadata = MetadataStorage.getMetadata();
+    const metadata = orm.getMetadata().getAll();
     expect(metadata).toBeInstanceOf(Object);
-    expect(metadata[BaseEntity.name].properties.foo.type).toBe('string');
     expect(metadata[Author.name]).toBeInstanceOf(Object);
     expect(metadata[Author.name].path).toBe(Utils.normalizePath(__dirname, 'entities/Author.ts'));
     expect(metadata[Author.name].toJsonParams).toEqual(['strict', 'strip']);

--- a/tests/EntityHelper.mysql.test.ts
+++ b/tests/EntityHelper.mysql.test.ts
@@ -9,7 +9,7 @@ describe('EntityHelperMySql', () => {
 
   beforeAll(async () => {
     orm = await initORMMySql();
-    await new MetadataDiscovery(orm.em, orm.config, orm.config.getLogger()).discover();
+    await new MetadataDiscovery(orm.getMetadata(), orm.em.getDriver().getPlatform(), orm.config, orm.config.getLogger()).discover();
   });
   beforeEach(async () => wipeDatabaseMySql(orm.em));
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -250,8 +250,7 @@ describe('EntityManagerMongo', () => {
     const fork = orm.em.fork();
 
     expect(fork).not.toBe(orm.em);
-    // @ts-ignore
-    expect(fork.metadata).toBe(orm.em.metadata);
+    expect(fork.getMetadata()).toBe(orm.em.getMetadata());
     expect(fork.getUnitOfWork().getIdentityMap()).toEqual({});
 
     // request context is not started so we can use UoW and EF getters

--- a/tests/EntityManager.mysql.test.ts
+++ b/tests/EntityManager.mysql.test.ts
@@ -1062,7 +1062,7 @@ describe('EntityManagerMySql', () => {
     author2.favouriteBook = book;
     author2.version = 123;
     await orm.em.persistAndFlush([author1, author2, book]);
-    const diff = Utils.diffEntities(author1, author2);
+    const diff = Utils.diffEntities(author1, author2, orm.getMetadata());
     expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.uuid });
     expect(typeof diff.favouriteBook).toBe('string');
     expect(diff.favouriteBook).toBe(book.uuid);

--- a/tests/EntityManager.postgre.test.ts
+++ b/tests/EntityManager.postgre.test.ts
@@ -915,7 +915,7 @@ describe('EntityManagerPostgre', () => {
     author2.favouriteBook = book;
     author2.version = 123;
     await orm.em.persistAndFlush([author1, author2, book]);
-    const diff = Utils.diffEntities(author1, author2);
+    const diff = Utils.diffEntities(author1, author2, orm.getMetadata());
     expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.uuid });
     expect(typeof diff.favouriteBook).toBe('string');
     expect(diff.favouriteBook).toBe(book.uuid);

--- a/tests/EntityManager.sqlite.test.ts
+++ b/tests/EntityManager.sqlite.test.ts
@@ -810,7 +810,7 @@ describe('EntityManagerSqlite', () => {
     author2.favouriteBook = book;
     author2.version = 123;
     await orm.em.persist([author1, author2, book], true);
-    const diff = Utils.diffEntities(author1, author2);
+    const diff = Utils.diffEntities(author1, author2, orm.getMetadata());
     expect(diff).toMatchObject({ name: 'Name 2', favouriteBook: book.id });
     expect(typeof diff.favouriteBook).toBe('number');
   });

--- a/tests/MetadataValidator.test.ts
+++ b/tests/MetadataValidator.test.ts
@@ -1,5 +1,5 @@
 import { ReferenceType } from '../lib/entity';
-import { MetadataValidator } from '../lib/metadata';
+import { MetadataStorage, MetadataValidator } from '../lib/metadata';
 import { MikroORM } from '../lib';
 import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2 } from './entities-sql';
 import { BASE_DIR } from './bootstrap';
@@ -10,69 +10,69 @@ describe('MetadataValidator', () => {
 
   test('validates entity definition', async () => {
     const meta = { Author: { name: 'Author', properties: {} } } as any;
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError('Author entity is missing @PrimaryKey()');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError('Author entity is missing @PrimaryKey()');
 
     meta.Author.primaryKey = '_id';
     meta.Author.properties.test = { name: 'test', reference: ReferenceType.MANY_TO_ONE };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError('Author.test is missing type definition');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError('Author.test is missing type definition');
 
     meta.Author.properties.test.type = 'Test';
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError('Author.test has unknown type: Test');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError('Author.test has unknown type: Test');
 
     meta.Test = { name: 'Test', properties: {} };
     meta.Author.properties.tests = { name: 'tests', reference: ReferenceType.ONE_TO_MANY, type: 'Test', mappedBy: 'foo' };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Author.tests has unknown 'mappedBy' reference: Test.foo`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.tests has unknown 'mappedBy' reference: Test.foo`);
 
     meta.Test.properties.foo = { name: 'foo', reference: ReferenceType.MANY_TO_ONE, type: 'Wrong', mappedBy: 'foo' };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Author.tests has wrong 'mappedBy' reference type: Wrong instead of Author`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.tests has wrong 'mappedBy' reference type: Wrong instead of Author`);
 
     meta.Test.properties.foo.type = 'Author';
     meta.Author.properties.books = { name: 'books', reference: ReferenceType.MANY_TO_MANY, type: 'Book' };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError('Author.books has unknown type: Book');
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError('Author.books has unknown type: Book');
 
     // many to many inversedBy
     meta.Book = { name: 'Book', properties: {} };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Author.books needs to have one of 'owner', 'mappedBy' or 'inversedBy' attributes`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.books needs to have one of 'owner', 'mappedBy' or 'inversedBy' attributes`);
 
     meta.Author.properties.books = { name: 'books', reference: ReferenceType.MANY_TO_MANY, type: 'Book', inversedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Author.books has unknown 'inversedBy' reference: Book.bar`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.books has unknown 'inversedBy' reference: Book.bar`);
 
     meta.Author.properties.books.inversedBy = 'authors';
     meta.Book.properties.authors = { name: 'authors', reference: ReferenceType.MANY_TO_MANY, type: 'Foo', inversedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Author.books has wrong 'inversedBy' reference type: Foo instead of Author`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.books has wrong 'inversedBy' reference type: Foo instead of Author`);
 
     meta.Book.properties.authors = { name: 'authors', reference: ReferenceType.MANY_TO_MANY, type: 'Author', inversedBy: 'books' };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Both Author.books and Book.authors are defined as owning sides, use mappedBy on one of them`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Both Author.books and Book.authors are defined as owning sides, use mappedBy on one of them`);
 
     // many to many mappedBy
     meta.Author.properties.books = { name: 'books', reference: ReferenceType.MANY_TO_MANY, type: 'Book', mappedBy: 'bar' };
     meta.Book = { name: 'Book', properties: {} };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Author.books has unknown 'mappedBy' reference: Book.bar`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.books has unknown 'mappedBy' reference: Book.bar`);
 
     meta.Author.properties.books.mappedBy = 'authors';
     meta.Book.properties.authors = { name: 'authors', reference: ReferenceType.MANY_TO_MANY, type: 'Foo', mappedBy: 'bar' };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Author.books has wrong 'mappedBy' reference type: Foo instead of Author`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Author.books has wrong 'mappedBy' reference type: Foo instead of Author`);
 
     meta.Book.properties.authors = { name: 'authors', reference: ReferenceType.MANY_TO_MANY, type: 'Author', mappedBy: 'books' };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Both Author.books and Book.authors are defined as inverse sides, use inversedBy on one of them`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Both Author.books and Book.authors are defined as inverse sides, use inversedBy on one of them`);
 
     // version field
     meta.Book.properties.authors = { name: 'authors', reference: ReferenceType.MANY_TO_MANY, type: 'Author', inversedBy: 'books' };
     meta.Author.properties.version = { name: 'version', reference: ReferenceType.SCALAR, type: 'Test', version: true };
     meta.Author.versionProperty = 'version';
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Version property Author.version has unsupported type 'Test'. Only 'number' and 'Date' are allowed.`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Version property Author.version has unsupported type 'Test'. Only 'number' and 'Date' are allowed.`);
     meta.Author.properties.version.type = 'number';
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).not.toThrowError();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrowError();
     meta.Author.properties.version.type = 'Date';
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).not.toThrowError();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrowError();
     meta.Author.properties.version.type = 'timestamp(3)';
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).not.toThrowError();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrowError();
     meta.Author.properties.version.type = 'datetime(6)';
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).not.toThrowError();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrowError();
     meta.Author.properties.version2 = { name: 'version2', reference: ReferenceType.SCALAR, type: 'number', version: true };
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).toThrowError(`Entity Author has multiple version properties defined: 'version', 'version2'. Only one version property is allowed per entity.`);
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).toThrowError(`Entity Author has multiple version properties defined: 'version', 'version2'. Only one version property is allowed per entity.`);
     delete meta.Author.properties.version2;
-    expect(() => validator.validateEntityDefinition(meta as any, 'Author')).not.toThrowError();
+    expect(() => validator.validateEntityDefinition(new MetadataStorage(meta as any), 'Author')).not.toThrowError();
   });
 
   test('validates missing base entity definition', async () => {

--- a/tests/UnitOfWork.test.ts
+++ b/tests/UnitOfWork.test.ts
@@ -2,7 +2,6 @@ import { Author } from './entities';
 import { EntityValidator, MikroORM } from '../lib';
 import { UnitOfWork, ChangeSetComputer } from '../lib/unit-of-work';
 import { initORM, wipeDatabase } from './bootstrap';
-import { MetadataStorage } from '../lib/metadata';
 
 describe('UnitOfWork', () => {
 
@@ -78,7 +77,7 @@ describe('UnitOfWork', () => {
 
     // string date with correct format will not be auto-corrected in strict mode
     const payload = { name: '333', email: '444', born: '2018-01-01', termsAccepted: 1 };
-    expect(() => validator.validate(author, payload, MetadataStorage.getMetadata(Author.name))).toThrowError(`Trying to set Author.born of type 'date' to '2018-01-01' of type 'string'`);
+    expect(() => validator.validate(author, payload, orm.getMetadata().get(Author.name))).toThrowError(`Trying to set Author.born of type 'date' to '2018-01-01' of type 'string'`);
   });
 
   test('changeSet is null for empty payload', async () => {

--- a/tests/entities-js/BaseEntity4.js
+++ b/tests/entities-js/BaseEntity4.js
@@ -1,4 +1,3 @@
-const { MetadataStorage } = require('../../lib/metadata');
 const { Collection, ReferenceType } = require('../../lib');
 
 /**
@@ -7,7 +6,7 @@ const { Collection, ReferenceType } = require('../../lib');
 class BaseEntity4 {
 
   constructor() {
-    const meta = MetadataStorage.getMetadata(this.constructor.name);
+    const meta = this['__em'].getMetadata().get(this.constructor.name);
     const props = meta.properties;
 
     Object.keys(props).forEach(prop => {


### PR DESCRIPTION
Previously there was only static metadata storage, used across the whole ORM. It is still needed for initial gathering of decorator metadata, but then ORM will create new instance based on this global state and work with that internally.

This means that the global one will contain only decorator data, not the computed one like naming strategy defaults, etc. Those are now stored only in the instance one, accessible via `orm.getMetadata()` and `em.getMetadata()`.