### PR TITLE
feat(schema): add basic entity generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist
 /coverage
 /temp
+/tests/generated-entities
 /.idea
 /yarn-error.log
 /.coveralls.yml

--- a/lib/MikroORM.ts
+++ b/lib/MikroORM.ts
@@ -3,6 +3,7 @@ import { AbstractSqlDriver, IDatabaseDriver } from './drivers';
 import { MetadataDiscovery, MetadataStorage } from './metadata';
 import { Configuration, Logger, Options } from './utils';
 import { SchemaGenerator } from './schema';
+import { EntityGenerator } from './schema/EntityGenerator';
 
 export class MikroORM {
 
@@ -65,6 +66,10 @@ export class MikroORM {
 
   getSchemaGenerator(): SchemaGenerator {
     return new SchemaGenerator(this.driver as AbstractSqlDriver, this.metadata);
+  }
+
+  getEntityGenerator(): EntityGenerator {
+    return new EntityGenerator(this.driver as AbstractSqlDriver, this.config);
   }
 
 }

--- a/lib/entity/EntityValidator.ts
+++ b/lib/entity/EntityValidator.ts
@@ -82,7 +82,7 @@ export class EntityValidator {
   }
 
   private fixTypes(expectedType: string, givenType: string, givenValue: any): any {
-    if (expectedType === 'date' && givenType === 'string') {
+    if (expectedType === 'date' && ['string', 'number'].includes(givenType)) {
       givenValue = this.fixDateType(givenValue);
     }
 

--- a/lib/metadata/MetadataDiscovery.ts
+++ b/lib/metadata/MetadataDiscovery.ts
@@ -205,12 +205,8 @@ export class MetadataDiscovery {
     this.validator.validateEntityDefinition(this.metadata, meta.name);
     Object.values(meta.properties).forEach(prop => {
       this.applyNamingStrategy(meta, prop);
+      this.initVersionProperty(meta, prop);
       this.initColumnType(prop);
-
-      if (prop.version) {
-        meta.versionProperty = prop.name;
-        prop.default = this.getDefaultVersionValue(prop);
-      }
     });
     meta.serializedPrimaryKey = this.platform.getSerializedPrimaryKeyField(meta.primaryKey);
     const ret: EntityMetadata[] = [];
@@ -298,11 +294,20 @@ export class MetadataDiscovery {
     }
 
     if (prop.type.toLowerCase() === 'date') {
-      prop.length = prop.length || 3;
+      prop.length = typeof prop.length === 'undefined' ? 3 : prop.length;
       return this.platform.getCurrentTimestampSQL(prop.length);
     }
 
     return 1;
+  }
+
+  private initVersionProperty(meta: EntityMetadata, prop: EntityProperty): void {
+    if (!prop.version) {
+      return;
+    }
+
+    meta.versionProperty = prop.name;
+    prop.default = this.getDefaultVersionValue(prop);
   }
 
   private initColumnType(prop: EntityProperty): void {

--- a/lib/naming-strategy/AbstractNamingStrategy.ts
+++ b/lib/naming-strategy/AbstractNamingStrategy.ts
@@ -2,9 +2,9 @@ import { NamingStrategy } from './NamingStrategy';
 
 export abstract class AbstractNamingStrategy implements NamingStrategy {
 
-  getClassName(file: string): string {
+  getClassName(file: string, separator = '-'): string {
     const name = file.split('.')[0];
-    const ret = name.replace(/-(\w)/, m => m[1].toUpperCase());
+    const ret = name.replace(new RegExp(`${separator}+(\\w)`, 'g'), m => m[1].toUpperCase());
 
     return ret.charAt(0).toUpperCase() + ret.slice(1);
   }

--- a/lib/naming-strategy/NamingStrategy.ts
+++ b/lib/naming-strategy/NamingStrategy.ts
@@ -3,7 +3,7 @@ export interface NamingStrategy {
   /**
    * Return a name of the class based on its file name
    */
-  getClassName(file: string): string;
+  getClassName(file: string, separator?: string): string;
 
   /**
    * Return a table name for an entity class

--- a/lib/platforms/PostgreSqlPlatform.ts
+++ b/lib/platforms/PostgreSqlPlatform.ts
@@ -13,4 +13,8 @@ export class PostgreSqlPlatform extends Platform {
     return true;
   }
 
+  getCurrentTimestampSQL(length: number): string {
+    return `current_timestamp(${length})`;
+  }
+
 }

--- a/lib/schema/EntityGenerator.ts
+++ b/lib/schema/EntityGenerator.ts
@@ -1,0 +1,217 @@
+import { CodeBlockWriter, Project, QuoteKind, SourceFile } from 'ts-morph';
+import { ensureDir, writeFile } from 'fs-extra';
+
+import { AbstractSqlDriver, Configuration, TableDefinition, Utils } from '..';
+import { Platform } from '../platforms';
+import { EntityProperty } from '../decorators';
+
+export class EntityGenerator {
+
+  private readonly platform: Platform = this.driver.getPlatform();
+  private readonly helper = this.platform.getSchemaHelper()!;
+  private readonly connection = this.driver.getConnection();
+  private readonly namingStrategy = this.config.getNamingStrategy();
+  private readonly project = new Project();
+  private readonly sources: SourceFile[] = [];
+
+  constructor(private readonly driver: AbstractSqlDriver,
+              private readonly config: Configuration) {
+    this.project.manipulationSettings.set({ quoteKind: QuoteKind.Single });
+  }
+
+  async generate(options: { baseDir?: string; save?: boolean } = {}): Promise<string[]> {
+    const baseDir = options.baseDir || Utils.normalizePath(this.config.get('baseDir'), 'generated-entities');
+    const tables = await this.connection.execute<TableDefinition[]>(this.helper.getListTablesSQL());
+
+    for (const table of tables) {
+      await this.createEntity(table.table_name, table.schema_name);
+    }
+
+    this.sources.forEach(entity => {
+      entity.fixMissingImports();
+      entity.fixUnusedIdentifiers();
+      entity.organizeImports();
+    });
+
+    if (options.save) {
+      await ensureDir(baseDir);
+      await Promise.all(this.sources.map(e => writeFile(baseDir + '/' + e.getBaseName(), e.getFullText())));
+    }
+
+    return this.sources.map(e => e.getFullText());
+  }
+
+  async createEntity(tableName: string, schemaName?: string): Promise<void> {
+    const cols = await this.helper.getColumns(this.connection, tableName, schemaName);
+    const indexes = await this.helper.getIndexes(this.connection, tableName, schemaName);
+    const pks = await this.helper.getPrimaryKeys(this.connection, indexes, tableName, schemaName);
+    const fks = await this.getForeignKeys(tableName, schemaName);
+    const entity = this.project.createSourceFile(this.namingStrategy.getClassName(tableName, '_') + '.ts', writer => {
+      writer.writeLine(`import { Entity, PrimaryKey, Property, ManyToOne, OneToMany, OneToOne, ManyToMany, Cascade } from 'mikro-orm';`);
+      writer.blankLine();
+      writer.writeLine('@Entity()');
+      writer.write(`export class ${this.namingStrategy.getClassName(tableName, '_')}`);
+      writer.block(() => cols.forEach(def => this.createProperty(writer, def, pks, indexes[def.name], fks[def.name])));
+      writer.write('');
+    });
+
+    this.sources.push(entity);
+  }
+
+  private async getForeignKeys(tableName: string, schemaName?: string): Promise<Record<string, any>> {
+    const fks = await this.connection.execute<any[]>(this.helper.getForeignKeysSQL(tableName, schemaName));
+    return this.helper.mapForeignKeys(fks);
+  }
+
+  private createProperty(writer: CodeBlockWriter, def: any, pks: string[], index: any[], fk: any): void {
+    const prop = this.getPropertyName(def.name, fk);
+    const type = this.getPropertyType(def.type, fk);
+    const defaultValue = this.getPropertyDefaultValue(def, type);
+    const decorator = this.getPropertyDecorator(prop, def, type, defaultValue, pks, index, fk);
+    const definition = this.getPropertyDefinition(prop, type, defaultValue);
+
+    writer.blankLineIfLastNot();
+    writer.writeLine(decorator);
+    writer.writeLine(definition);
+    writer.blankLine();
+  }
+
+  private getPropertyDefinition(prop: string, type: string, defaultValue: any): string {
+    // string defaults are usually things like SQL functions
+    if (!defaultValue || typeof defaultValue === 'string') {
+      return `${prop}: ${type};`;
+    }
+
+    return `${prop}: ${type} = ${defaultValue};`;
+  }
+
+  private getPropertyDecorator(prop: string, def: Record<string, any>, type: string, defaultValue: any, pks: string[], index: any[], fk: any): string {
+    const options = {} as any;
+    const decorator = this.getDecoratorType(def, pks, index, fk);
+
+    if (fk) {
+      this.getForeignKeyDecoratorOptions(options, fk, def, prop);
+    } else {
+      this.getScalarPropertyDecoratorOptions(type, def, options, prop);
+    }
+
+    this.getCommonDecoratorOptions(def, options, defaultValue);
+
+    if (Object.keys(options).length === 0) {
+      return decorator + '()';
+    }
+
+    return `${decorator}({ ${Object.entries(options).map(([opt, val]) => `${opt}: ${val}`).join(', ')} })`;
+  }
+
+  private getCommonDecoratorOptions(def: any, options: Record<string, any>, defaultValue: any) {
+    if (def.nullable) {
+      options.nullable = true;
+    }
+
+    if (defaultValue && typeof defaultValue === 'string') {
+      options.default = `\`${defaultValue}\``;
+    }
+  }
+
+  private getScalarPropertyDecoratorOptions(type: string, def: any, options: Record<string, any>, prop: string) {
+    const defaultColumnType = this.helper.getTypeDefinition({
+      type,
+      length: def.maxLength,
+    } as EntityProperty).replace(/\(\d+\)/, '');
+
+    if (def.type !== defaultColumnType) {
+      options.type = `'${def.type}'`;
+    }
+
+    if (def.name !== this.namingStrategy.propertyToColumnName(prop)) {
+      options.fieldName = `'${def.name}'`;
+    }
+
+    if (def.maxLength) {
+      options.length = def.maxLength;
+    }
+  }
+
+  private getForeignKeyDecoratorOptions(options: Record<string, any>, fk: any, def: any, prop: string) {
+    options.entity = `() => ${this.namingStrategy.getClassName(fk.referencedTableName, '_')}`;
+
+    if (def.name !== this.namingStrategy.joinKeyColumnName(prop, fk.referencedColumnName)) {
+      options.fieldName = `'${def.name}'`;
+    }
+
+    const cascade = ['Cascade.MERGE'];
+
+    if (fk.updateRule.toLowerCase() === 'cascade') {
+      cascade.push('Cascade.PERSIST');
+    }
+
+    if (fk.deleteRule.toLowerCase() === 'cascade') {
+      cascade.push('Cascade.REMOVE');
+    }
+
+    if (cascade.length === 3) {
+      cascade.length = 0;
+      cascade.push('Cascade.ALL');
+    }
+
+    if (!(cascade.length === 2 && cascade.includes('Cascade.PERSIST') && cascade.includes('Cascade.MERGE'))) {
+      options.cascade = `[${cascade.sort().join(', ')}]`;
+    }
+  }
+
+  private getDecoratorType(def: any, pks: string[], index: any[], fk: any): string {
+    const primary = pks.includes(def.name);
+
+    if (primary) {
+      return '@PrimaryKey';
+    }
+
+    if (fk && index && index.some(i => i.unique)) {
+      return '@OneToOne';
+    }
+
+    if (fk) {
+      return '@ManyToOne';
+    }
+
+    return '@Property';
+  }
+
+  private getPropertyName(field: string, fk: any): string {
+    if (fk) {
+      field = field.replace(new RegExp(`_${fk.referencedColumnName}$`), '');
+    }
+
+    return field.replace(/_(\w)/g, m => m[1].toUpperCase()).replace(/_+/g, '');
+  }
+
+  private getPropertyType(type: string, fk: any): string {
+    if (fk) {
+      return this.namingStrategy.getClassName(fk.referencedTableName, '_');
+    }
+
+    return this.helper.getTypeFromDefinition(type);
+  }
+
+  private getPropertyDefaultValue(def: any, propType: string): any {
+    if (!def.nullable && def.defaultValue === null) {
+      return;
+    }
+
+    if (!def.defaultValue) {
+      return;
+    }
+
+    if (propType === 'boolean') {
+      return !!def.defaultValue;
+    }
+
+    if (propType === 'number') {
+      return +def.defaultValue;
+    }
+
+    return '' + def.defaultValue;
+  }
+
+}

--- a/lib/schema/MySqlSchemaHelper.ts
+++ b/lib/schema/MySqlSchemaHelper.ts
@@ -1,17 +1,20 @@
 import { MySqlTableBuilder } from 'knex';
 import { SchemaHelper } from './SchemaHelper';
 import { EntityProperty } from '../decorators';
+import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 
 export class MySqlSchemaHelper extends SchemaHelper {
 
   static readonly TYPES = {
-    number: ['int(?)', 'float', 'double'],
+    number: ['int(?)', 'int', 'float', 'double'],
     float: ['float'],
     double: ['double'],
-    string: ['varchar(?)', 'text'],
-    date: ['datetime(?)', 'timestamp(?)'],
-    boolean: ['tinyint(1)'],
+    string: ['varchar(?)', 'varchar', 'text'],
+    Date: ['datetime(?)', 'timestamp(?)', 'datetime', 'timestamp'],
+    date: ['datetime(?)', 'timestamp(?)', 'datetime', 'timestamp'],
+    boolean: ['tinyint(1)', 'tinyint'],
     text: ['text'],
+    object: ['json'],
     json: ['json'],
   };
 
@@ -36,6 +39,54 @@ export class MySqlSchemaHelper extends SchemaHelper {
 
   getTypeDefinition(prop: EntityProperty): string {
     return super.getTypeDefinition(prop, MySqlSchemaHelper.TYPES, MySqlSchemaHelper.DEFAULT_TYPE_LENGTHS);
+  }
+
+  getTypeFromDefinition(type: string): string {
+    return super.getTypeFromDefinition(type, MySqlSchemaHelper.TYPES);
+  }
+
+  getListTablesSQL(): string {
+    return `select table_name from information_schema.tables where table_type = 'BASE TABLE' and table_schema = schema()`;
+  }
+
+  getForeignKeysSQL(tableName: string, schemaName?: string): string {
+    return `select distinct k.constraint_name, k.column_name, k.referenced_table_name, k.referenced_column_name, c.update_rule, c.delete_rule `
+      + `from information_schema.key_column_usage k `
+      + `inner join information_schema.referential_constraints c on c.constraint_name = k.constraint_name and c.table_name = '${tableName}' `
+      + `where k.table_name = '${tableName}' and k.table_schema = database() and c.constraint_schema = database() and k.referenced_column_name is not null`;
+  }
+
+  async getColumns(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<any[]> {
+    const sql = `select column_name, column_default, is_nullable, data_type, column_key, ifnull(datetime_precision, character_maximum_length) length
+      from information_schema.columns where table_schema = database() and table_name = '${tableName}'`;
+    const columns = await connection.execute<any[]>(sql);
+
+    return columns.map(col => ({
+      name: col.column_name,
+      type: col.data_type,
+      maxLength: col.length,
+      defaultValue: col.column_default,
+      nullable: col.is_nullable === 'YES',
+      primary: col.column_key === 'PRI',
+      unique: col.column_key === 'UNI',
+    }));
+  }
+
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Record<string, any[]>> {
+    const sql = `show index from \`${tableName}\``;
+    const indexes = await connection.execute<any[]>(sql);
+
+    return indexes.reduce((ret, index: any) => {
+      ret[index.Column_name] = ret[index.Column_name] || [];
+      ret[index.Column_name].push({
+        columnName: index.Column_name,
+        keyName: index.Key_name,
+        unique: !index.Non_unique,
+        primary: index.Key_name === 'PRIMARY',
+      });
+
+      return ret;
+    }, {});
   }
 
 }

--- a/lib/schema/PostgreSqlSchemaHelper.ts
+++ b/lib/schema/PostgreSqlSchemaHelper.ts
@@ -1,22 +1,20 @@
 import { SchemaHelper } from './SchemaHelper';
 import { EntityProperty } from '../decorators';
+import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 
 export class PostgreSqlSchemaHelper extends SchemaHelper {
 
   static readonly TYPES = {
-    number: ['int', 'int8', 'integer', 'float', 'float8', 'double', 'double precision', 'bigint', 'smallint', 'decimal', 'numeric', 'real'],
+    number: ['int4', 'integer', 'int8', 'int', 'float', 'float8', 'double', 'double precision', 'bigint', 'smallint', 'decimal', 'numeric', 'real'],
     float: ['float'],
     double: ['double', 'double precision', 'float8'],
     string: ['varchar(?)', 'character varying', 'text', 'character', 'char'],
-    date: ['datetime(?)', 'timestamp(?)', 'timestamp without time zone', 'timestamptz', 'datetimetz', 'time', 'date', 'timetz', 'datetz'],
-    boolean: ['boolean', 'bool'],
+    Date: ['timestamp(?)', 'datetime(?)', 'timestamp without time zone', 'timestamptz', 'datetimetz', 'time', 'date', 'timetz', 'datetz'],
+    date: ['timestamp(?)', 'datetime(?)', 'timestamp without time zone', 'timestamptz', 'datetimetz', 'time', 'date', 'timetz', 'datetz'],
+    boolean: ['bool', 'boolean'],
     text: ['text'],
+    object: ['json'],
     json: ['json'],
-  };
-
-  static readonly DEFAULT_VALUES = {
-    'now()': ['now()', 'current_timestamp'],
-    "('now'::text)::timestamp(?) with time zone": ['current_timestamp(?)'],
   };
 
   static readonly DEFAULT_TYPE_LENGTHS = {
@@ -33,11 +31,80 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   }
 
   getTypeDefinition(prop: EntityProperty): string {
-    return super.getTypeDefinition(prop, PostgreSqlSchemaHelper.TYPES, PostgreSqlSchemaHelper.DEFAULT_TYPE_LENGTHS);
+    return super.getTypeDefinition(prop, PostgreSqlSchemaHelper.TYPES, PostgreSqlSchemaHelper.DEFAULT_TYPE_LENGTHS, true);
+  }
+
+  getTypeFromDefinition(type: string): string {
+    return super.getTypeFromDefinition(type, PostgreSqlSchemaHelper.TYPES);
   }
 
   indexForeignKeys() {
     return false;
+  }
+
+  getListTablesSQL(): string {
+    return 'select quote_ident(table_name) as table_name, table_schema as schema_name '
+      + `from information_schema.tables where table_schema not like 'pg\_%' and table_schema != 'information_schema' `
+      + `and table_name != 'geometry_columns' and table_name != 'spatial_ref_sys' and table_type != 'VIEW' order by table_name`;
+  }
+
+  async getColumns(connection: AbstractSqlConnection, tableName: string, schemaName: string): Promise<any[]> {
+    const sql = `select column_name, column_default, is_nullable, udt_name, coalesce(datetime_precision, character_maximum_length) length
+      from information_schema.columns where table_schema = '${schemaName}' and table_name = '${tableName}'`;
+    const columns = await connection.execute<any[]>(sql);
+
+    return columns.map(col => ({
+      name: col.column_name,
+      type: col.udt_name,
+      maxLength: col.length,
+      defaultValue: col.column_default,
+      nullable: col.is_nullable === 'YES',
+    }));
+  }
+
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName: string): Promise<Record<string, any[]>> {
+    const sql = this.getIndexesSQL(tableName, schemaName);
+    const indexes = await connection.execute<any[]>(sql);
+
+    return indexes.reduce((ret, index: any) => {
+      ret[index.column_name] = ret[index.column_name] || [];
+      ret[index.column_name].push({
+        columnName: index.column_name,
+        keyName: index.constraint_name,
+        unique: index.unique,
+        primary: index.primary,
+      });
+
+      return ret;
+    }, {});
+  }
+
+  getForeignKeysSQL(tableName: string, schemaName: string): string {
+    return `select kcu.table_name as table_name, rel_kcu.table_name as referenced_table_name, kcu.column_name as column_name,
+      rel_kcu.column_name as referenced_column_name, kcu.constraint_name, rco.update_rule, rco.delete_rule
+      from information_schema.table_constraints tco
+      join information_schema.key_column_usage kcu
+        on tco.constraint_schema = kcu.constraint_schema
+        and tco.constraint_name = kcu.constraint_name
+      join information_schema.referential_constraints rco
+        on tco.constraint_schema = rco.constraint_schema
+        and tco.constraint_name = rco.constraint_name
+      join information_schema.key_column_usage rel_kcu
+        on rco.unique_constraint_schema = rel_kcu.constraint_schema
+        and rco.unique_constraint_name = rel_kcu.constraint_name
+        and kcu.ordinal_position = rel_kcu.ordinal_position
+      where tco.table_name = '${tableName}' and tco.table_schema = '${schemaName}' and tco.constraint_schema = '${schemaName}' and tco.constraint_type = 'FOREIGN KEY'
+      order by kcu.table_schema, kcu.table_name, kcu.ordinal_position`;
+  }
+
+  private getIndexesSQL(tableName: string, schemaName: string): string {
+    return `select i.indexname as constraint_name, k.column_name, c.contype = 'u' as unique, c.contype = 'p' as primary
+         from pg_catalog.pg_indexes i
+         join pg_catalog.pg_constraint c on c.conname = i.indexname
+         join pg_catalog.pg_class rel on rel.oid = c.conrelid
+         join pg_catalog.pg_namespace nsp on nsp.oid = c.connamespace
+         join information_schema.key_column_usage k on k.constraint_name = c.conname and k.table_schema = 'public' and k.table_name = '${tableName}'
+         where nsp.nspname = '${schemaName}' and rel.relname = '${tableName}'`;
   }
 
 }

--- a/lib/schema/SchemaGenerator.ts
+++ b/lib/schema/SchemaGenerator.ts
@@ -4,6 +4,11 @@ import { EntityMetadata, EntityProperty } from '../decorators';
 import { Platform } from '../platforms';
 import { MetadataStorage } from '../metadata';
 
+export interface TableDefinition {
+  table_name: string;
+  schema_name?: string;
+}
+
 export class SchemaGenerator {
 
   private readonly platform: Platform = this.driver.getPlatform();

--- a/lib/schema/SchemaHelper.ts
+++ b/lib/schema/SchemaHelper.ts
@@ -1,5 +1,6 @@
 import { TableBuilder } from 'knex';
 import { EntityProperty } from '../decorators';
+import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 
 export abstract class SchemaHelper {
 
@@ -15,13 +16,12 @@ export abstract class SchemaHelper {
     //
   }
 
-  getTypeDefinition(prop: EntityProperty, types: Record<string, string[]> = {}, lengths: Record<string, number> = {}): string {
+  getTypeDefinition(prop: EntityProperty, types: Record<string, string[]> = {}, lengths: Record<string, number> = {}, allowZero = false): string {
     const t = prop.type.toLowerCase();
     let type = (types[t] || types.json || types.text || [t])[0];
 
     if (type.includes('(?)')) {
-      const length = prop.length || lengths[t];
-      type = length ? type.replace('?', length) : type.replace('(?)', '');
+      type = this.processTypeWildCard(prop, lengths, t, allowZero, type);
     }
 
     return type;
@@ -33,6 +33,68 @@ export abstract class SchemaHelper {
 
   indexForeignKeys() {
     return true;
+  }
+
+  getTypeFromDefinition(type: string, types?: Record<string, string[]>): string {
+    type = type.replace(/\(.+\)/, '');
+
+    return Object.entries(types!)
+      .filter(([, tt]) => tt.find(ttt => ttt.replace(/\(.+\)/, '') === type))
+      .map(([t]) => t)[0];
+  }
+
+  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: Record<string, any[]>, tableName: string, schemaName?: string): Promise<string[]> {
+    const ret = [];
+
+    for (const idx of Object.values(indexes)) {
+      const pks = idx.filter(i => i.primary).map(i => i.columnName);
+      ret.push(...pks);
+    }
+
+    return ret;
+  }
+
+  getListTablesSQL(): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  async getColumns(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<any[]> {
+    throw new Error('Not supported by given driver');
+  }
+
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Record<string, any[]>> {
+    throw new Error('Not supported by given driver');
+  }
+
+  getForeignKeysSQL(tableName: string, schemaName?: string): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  mapForeignKeys(fks: any[]): Record<string, any> {
+    return fks.reduce((ret, fk: any) => {
+      ret[fk.column_name] = {
+        columnName: fk.column_name,
+        constraintName: fk.constraint_name,
+        referencedTableName: fk.referenced_table_name,
+        referencedColumnName: fk.referenced_column_name,
+        updateRule: fk.update_rule,
+        deleteRule: fk.delete_rule,
+      };
+
+      return ret;
+    }, {});
+  }
+
+  private processTypeWildCard(prop: EntityProperty, lengths: Record<string, number>, propType: string, allowZero: boolean, type: string): string {
+    let length = prop.length || lengths[propType];
+
+    if (allowZero) {
+      length = '' + length;
+    }
+
+    type = length ? type.replace('?', length) : type.replace('(?)', '');
+
+    return type;
   }
 
 }

--- a/lib/schema/SqliteSchemaHelper.ts
+++ b/lib/schema/SqliteSchemaHelper.ts
@@ -1,13 +1,17 @@
 import { SchemaHelper } from './SchemaHelper';
 import { EntityProperty } from '../decorators';
+import { AbstractSqlConnection } from '../connections/AbstractSqlConnection';
 
 export class SqliteSchemaHelper extends SchemaHelper {
 
   static readonly TYPES = {
-    number: ['integer'],
-    boolean: ['integer'],
-    date: ['text'],
-    string: ['text'],
+    number: ['integer', 'int', 'bigint'],
+    boolean: ['integer', 'int'],
+    string: ['varchar', 'text'],
+    Date: ['datetime', 'text'],
+    date: ['datetime', 'text'],
+    object: ['text'],
+    text: ['text'],
   };
 
   getSchemaBeginning(): string {
@@ -23,8 +27,74 @@ export class SqliteSchemaHelper extends SchemaHelper {
     return (SqliteSchemaHelper.TYPES[t] || SqliteSchemaHelper.TYPES.string)[0];
   }
 
+  getTypeFromDefinition(type: string): string {
+    return super.getTypeFromDefinition(type, SqliteSchemaHelper.TYPES);
+  }
+
   supportsSchemaConstraints(): boolean {
     return false;
+  }
+
+  getListTablesSQL(): string {
+    return `select name as table_name from sqlite_master where type = 'table' and name != 'sqlite_sequence' and name != 'geometry_columns' and name != 'spatial_ref_sys' `
+      + `union all select name as table_name from sqlite_temp_master where type = 'table' order by name`;
+  }
+
+  async getColumns(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<any[]> {
+    const columns = await connection.execute<any[]>(`pragma table_info('${tableName}')`);
+
+    return columns.map(col => ({
+      name: col.name,
+      type: col.type,
+      defaultValue: col.dflt_value,
+      nullable: !col.notnull,
+      primary: !!col.pk,
+    }));
+  }
+
+  async getPrimaryKeys(connection: AbstractSqlConnection, indexes: Record<string, any>, tableName: string, schemaName?: string): Promise<string[]> {
+    const sql = `pragma table_info(\`${tableName}\`)`;
+    const cols = await connection.execute<{ pk: number; name: string }[]>(sql);
+
+    return cols.filter(col => !!col.pk).map(col => col.name);
+  }
+
+  async getIndexes(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<Record<string, any[]>> {
+    const indexes = await connection.execute<any[]>(`pragma index_list(\`${tableName}\`)`);
+
+    for (const index of indexes) {
+      const res = await connection.execute<any[]>(`pragma index_info(\`${index.name}\`)`);
+      index.column_name = res[0].name;
+    }
+
+    return indexes.reduce((ret, index) => {
+      ret[index.column_name] = ret[index.column_name] || [];
+      ret[index.column_name].push({
+        columnName: index.column_name,
+        keyName: index.name,
+        unique: !!index.unique,
+      });
+
+      return ret;
+    }, {});
+  }
+
+  getForeignKeysSQL(tableName: string): string {
+    return `pragma foreign_key_list(\`${tableName}\`)`;
+  }
+
+  mapForeignKeys(fks: any[]): Record<string, any> {
+    return fks.reduce((ret, fk: any) => {
+      ret[fk.from] = {
+        columnName: fk.from,
+        referencedTableName: fk.table,
+        referencedColumnName: fk.to,
+        updateRule: fk.on_update,
+        deleteRule: fk.on_delete,
+      };
+
+      return ret;
+    }, {});
   }
 
 }

--- a/lib/utils/Utils.ts
+++ b/lib/utils/Utils.ts
@@ -4,6 +4,7 @@ import clone from 'clone';
 import { MetadataStorage } from '../metadata';
 import { EntityData, EntityMetadata, EntityProperty, IEntity, IEntityType, IPrimaryKey } from '../decorators';
 import { ArrayCollection, Collection, ReferenceType } from '../entity';
+import { isAbsolute, normalize } from 'path';
 
 export class Utils {
 
@@ -243,7 +244,13 @@ export class Utils {
   }
 
   static normalizePath(...parts: string[]): string {
-    return parts.join('/').replace(/\\/g, '/');
+    let path = parts.join('/');
+
+    if (!isAbsolute(path)) {
+      path = process.cwd() + (path ? '/' + path : '');
+    }
+
+    return normalize(path).replace(/\\/g, '/');
   }
 
   static runIfNotEmpty(clause: () => any, data: any): void {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "rimraf dist && tsc",
     "test": "jest --runInBand",
-    "coverage": "rimraf temp && jest --runInBand --coverage",
+    "coverage": "rimraf temp tests/generated-entities && jest --runInBand --coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "tslint -p ."
   },

--- a/tests/EntityGenerator.test.ts
+++ b/tests/EntityGenerator.test.ts
@@ -1,0 +1,37 @@
+import { pathExists, remove } from 'fs-extra';
+import { initORMMySql, initORMPostgreSql, initORMSqlite } from './bootstrap';
+
+describe('EntityGenerator', () => {
+
+  test('generate entities from schema [mysql]', async () => {
+    const orm = await initORMMySql();
+    const generator = orm.getEntityGenerator();
+    const dump = await generator.generate({ save: true, baseDir: './temp/entities' });
+    expect(dump).toMatchSnapshot('mysql-entity-dump');
+    await expect(pathExists('./temp/entities/Author2.ts')).resolves.toBe(true);
+    await remove('./temp/entities');
+
+    await orm.close(true);
+  });
+
+  test('generate entities from schema [sqlite]', async () => {
+    const orm = await initORMSqlite();
+    const generator = orm.getEntityGenerator();
+    const dump = await generator.generate({ save: true });
+    expect(dump).toMatchSnapshot('sqlite-entity-dump');
+    await expect(pathExists('./tests/generated-entities/Author3.ts')).resolves.toBe(true);
+    await remove('./tests/generated-entities');
+
+    await orm.close(true);
+  });
+
+  test('generate entities from schema [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const generator = orm.getEntityGenerator();
+    const dump = await generator.generate();
+    expect(dump).toMatchSnapshot('postgres-entity-dump');
+
+    await orm.close(true);
+  });
+
+});

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -9,6 +9,10 @@ describe('SchemaHelper', () => {
     expect(helper.getSchemaBeginning()).toBe('');
     expect(helper.getSchemaEnd()).toBe('');
     expect(helper.getTypeDefinition({ type: 'test' } as any)).toBe('test');
+    expect(() => helper.getListTablesSQL()).toThrowError('Not supported by given driver');
+    expect(() => helper.getForeignKeysSQL('table')).toThrowError('Not supported by given driver');
+    await expect(helper.getColumns({} as any, 'table')).rejects.toThrowError('Not supported by given driver');
+    await expect(helper.getIndexes({} as any, 'table')).rejects.toThrowError('Not supported by given driver');
   });
 
 });

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -166,6 +166,13 @@ describe('Utils', () => {
     expect(Utils.extractPK({ uuid: 'uuid-123' }, meta)).toBe('uuid-123');
   });
 
+  test('normalizePath always returns absolute path', () => {
+    expect(Utils.normalizePath()).toBe(process.cwd());
+    expect(Utils.normalizePath('./test')).toBe(process.cwd() + '/test');
+    expect(Utils.normalizePath('test')).toBe(process.cwd() + '/test');
+    expect(Utils.normalizePath('/test')).toBe('/test');
+  });
+
   test('lookup path from decorator', () => {
     // with tslib, compiled
     const stack1 = [

--- a/tests/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/__snapshots__/EntityGenerator.test.ts.snap
@@ -1,0 +1,577 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EntityGenerator generate entities from schema [mysql]: mysql-entity-dump 1`] = `
+Array [
+  "import { Entity, ManyToOne, PrimaryKey, Property } from 'mikro-orm';
+import { Book2 } from './Book2';
+
+@Entity()
+export class Author2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 3, default: \`CURRENT_TIMESTAMP(3)\` })
+    createdAt: Date;
+
+    @Property({ length: 3, default: \`CURRENT_TIMESTAMP(3)\` })
+    updatedAt: Date;
+
+    @Property({ length: 255 })
+    name: string;
+
+    @Property({ length: 255 })
+    email: string;
+
+    @Property({ nullable: true })
+    age: number;
+
+    @Property()
+    termsAccepted: boolean = true;
+
+    @Property({ nullable: true })
+    identities: object;
+
+    @Property({ nullable: true })
+    born: Date;
+
+    @ManyToOne({ entity: () => Book2, nullable: true })
+    favouriteBook: Book2;
+
+    @ManyToOne({ entity: () => Author2, nullable: true })
+    favouriteAuthor: Author2;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne, PrimaryKey, Property } from 'mikro-orm';
+import { Author2 } from './Author2';
+import { Publisher2 } from './Publisher2';
+
+@Entity()
+export class Book2 {
+
+    @PrimaryKey({ length: 36 })
+    uuidPk: string;
+
+    @Property({ length: 3, default: \`CURRENT_TIMESTAMP(3)\` })
+    createdAt: Date;
+
+    @Property({ length: 255, nullable: true })
+    title: string;
+
+    @Property({ type: 'text', length: 65535, nullable: true })
+    perex: string;
+
+    @Property({ type: 'float', nullable: true })
+    price: number;
+
+    @Property({ type: 'double', nullable: true })
+    double: number;
+
+    @Property({ nullable: true })
+    meta: object;
+
+    @ManyToOne({ entity: () => Author2, cascade: [Cascade.MERGE], nullable: true })
+    author: Author2;
+
+    @ManyToOne({ entity: () => Publisher2, cascade: [Cascade.ALL], nullable: true })
+    publisher: Publisher2;
+
+    @Property({ length: 255, nullable: true })
+    foo: string;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne, PrimaryKey } from 'mikro-orm';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
+
+@Entity()
+export class Book2ToBookTag2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @ManyToOne({ entity: () => Book2, cascade: [Cascade.ALL] })
+    book2: Book2;
+
+    @ManyToOne({ entity: () => BookTag2, cascade: [Cascade.ALL] })
+    bookTag2: BookTag2;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class BookTag2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 50 })
+    name: string;
+
+}
+",
+  "import { Entity, OneToOne, PrimaryKey, Property } from 'mikro-orm';
+import { FooBaz2 } from './FooBaz2';
+
+@Entity()
+export class FooBar2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 255 })
+    name: string;
+
+    @OneToOne({ entity: () => FooBaz2, nullable: true })
+    baz: FooBaz2;
+
+    @OneToOne({ entity: () => FooBar2, nullable: true })
+    fooBar: FooBar2;
+
+    @Property({ length: 3, default: \`CURRENT_TIMESTAMP(3)\` })
+    version: Date;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class FooBaz2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 255 })
+    name: string;
+
+    @Property({ length: 3, default: \`CURRENT_TIMESTAMP(3)\` })
+    version: Date;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class Publisher2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 255 })
+    name: string;
+
+    @Property({ length: 10 })
+    type: string;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne, PrimaryKey } from 'mikro-orm';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
+
+@Entity()
+export class Publisher2ToTest2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @ManyToOne({ entity: () => Publisher2, cascade: [Cascade.ALL] })
+    publisher2: Publisher2;
+
+    @ManyToOne({ entity: () => Test2, cascade: [Cascade.ALL] })
+    test2: Test2;
+
+}
+",
+  "import { Cascade, Entity, OneToOne, PrimaryKey, Property } from 'mikro-orm';
+import { Book2 } from './Book2';
+import { FooBar2 } from './FooBar2';
+
+@Entity()
+export class Test2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 255, nullable: true })
+    name: string;
+
+    @OneToOne({ entity: () => Book2, cascade: [Cascade.MERGE], nullable: true })
+    book: Book2;
+
+    @Property()
+    version: number = 1;
+
+    @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', nullable: true })
+    fooBar: FooBar2;
+
+    @Property({ fieldName: 'foo___baz', nullable: true })
+    fooBaz: number;
+
+}
+",
+]
+`;
+
+exports[`EntityGenerator generate entities from schema [postgres]: postgres-entity-dump 1`] = `
+Array [
+  "import { Entity, ManyToOne, PrimaryKey, Property } from 'mikro-orm';
+import { Book2 } from './Book2';
+
+@Entity()
+export class Author2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 3, default: \`('now'::text)::timestamp(3) with time zone\` })
+    createdAt: Date;
+
+    @Property({ length: 3, default: \`('now'::text)::timestamp(3) with time zone\` })
+    updatedAt: Date;
+
+    @Property({ length: 255 })
+    name: string;
+
+    @Property({ length: 255 })
+    email: string;
+
+    @Property({ nullable: true })
+    age: number;
+
+    @Property()
+    termsAccepted: boolean = true;
+
+    @Property({ nullable: true })
+    identities: object;
+
+    @Property({ nullable: true })
+    born: Date;
+
+    @ManyToOne({ entity: () => Book2, nullable: true })
+    favouriteBook: Book2;
+
+    @ManyToOne({ entity: () => Author2, nullable: true })
+    favouriteAuthor: Author2;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne, PrimaryKey, Property } from 'mikro-orm';
+import { Author2 } from './Author2';
+import { Publisher2 } from './Publisher2';
+
+@Entity()
+export class Book2 {
+
+    @PrimaryKey({ length: 36 })
+    uuidPk: string;
+
+    @Property({ length: 3, default: \`('now'::text)::timestamp(3) with time zone\` })
+    createdAt: Date;
+
+    @Property({ length: 255, nullable: true })
+    title: string;
+
+    @Property({ type: 'text', nullable: true })
+    perex: string;
+
+    @Property({ type: 'float8', nullable: true })
+    price: number;
+
+    @Property({ type: 'float8', nullable: true })
+    double: number;
+
+    @Property({ nullable: true })
+    meta: object;
+
+    @ManyToOne({ entity: () => Author2, cascade: [Cascade.MERGE], nullable: true })
+    author: Author2;
+
+    @ManyToOne({ entity: () => Publisher2, cascade: [Cascade.ALL], nullable: true })
+    publisher: Publisher2;
+
+    @Property({ length: 255, nullable: true })
+    foo: string;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne, PrimaryKey } from 'mikro-orm';
+import { Book2 } from './Book2';
+import { BookTag2 } from './BookTag2';
+
+@Entity()
+export class Book2ToBookTag2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @ManyToOne({ entity: () => Book2, cascade: [Cascade.ALL] })
+    book2: Book2;
+
+    @ManyToOne({ entity: () => BookTag2, cascade: [Cascade.ALL] })
+    bookTag2: BookTag2;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class BookTag2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 50 })
+    name: string;
+
+}
+",
+  "import { Entity, OneToOne, PrimaryKey, Property } from 'mikro-orm';
+import { FooBaz2 } from './FooBaz2';
+
+@Entity()
+export class FooBar2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 255 })
+    name: string;
+
+    @OneToOne({ entity: () => FooBaz2, nullable: true })
+    baz: FooBaz2;
+
+    @OneToOne({ entity: () => FooBar2, nullable: true })
+    fooBar: FooBar2;
+
+    @Property({ length: 3, default: \`('now'::text)::timestamp(3) with time zone\` })
+    version: Date;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class FooBaz2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 255 })
+    name: string;
+
+    @Property({ length: 3, default: \`('now'::text)::timestamp(3) with time zone\` })
+    version: Date;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class Publisher2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 255 })
+    name: string;
+
+    @Property({ length: 10 })
+    type: string;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne, PrimaryKey } from 'mikro-orm';
+import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
+
+@Entity()
+export class Publisher2ToTest2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @ManyToOne({ entity: () => Publisher2, cascade: [Cascade.ALL] })
+    publisher2: Publisher2;
+
+    @ManyToOne({ entity: () => Test2, cascade: [Cascade.ALL] })
+    test2: Test2;
+
+}
+",
+  "import { Cascade, Entity, OneToOne, PrimaryKey, Property } from 'mikro-orm';
+import { Book2 } from './Book2';
+
+@Entity()
+export class Test2 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ length: 255, nullable: true })
+    name: string;
+
+    @OneToOne({ entity: () => Book2, cascade: [Cascade.MERGE], nullable: true })
+    book: Book2;
+
+    @Property()
+    version: number = 1;
+
+}
+",
+]
+`;
+
+exports[`EntityGenerator generate entities from schema [sqlite]: sqlite-entity-dump 1`] = `
+Array [
+  "import { Entity, ManyToOne, PrimaryKey, Property } from 'mikro-orm';
+import { Book3 } from './Book3';
+
+@Entity()
+export class Author3 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ nullable: true })
+    createdAt: Date;
+
+    @Property({ nullable: true })
+    updatedAt: Date;
+
+    @Property()
+    name: string;
+
+    @Property()
+    email: string;
+
+    @Property({ nullable: true })
+    age: number;
+
+    @Property()
+    termsAccepted: number;
+
+    @Property({ nullable: true })
+    identities: string;
+
+    @Property({ nullable: true })
+    born: Date;
+
+    @ManyToOne({ entity: () => Book3, nullable: true })
+    favouriteBook: Book3;
+
+}
+",
+  "import { Entity, ManyToOne, PrimaryKey, Property } from 'mikro-orm';
+import { Author3 } from './Author3';
+import { Publisher3 } from './Publisher3';
+
+@Entity()
+export class Book3 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property()
+    title: string;
+
+    @Property({ nullable: true })
+    foo: string;
+
+    @ManyToOne({ entity: () => Author3, nullable: true })
+    author: Author3;
+
+    @ManyToOne({ entity: () => Publisher3, nullable: true })
+    publisher: Publisher3;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne, PrimaryKey } from 'mikro-orm';
+import { Book3 } from './Book3';
+import { BookTag3 } from './BookTag3';
+
+@Entity()
+export class Book3ToBookTag3 {
+
+    @PrimaryKey()
+    id: number;
+
+    @ManyToOne({ entity: () => Book3, cascade: [Cascade.ALL], nullable: true })
+    book3: Book3;
+
+    @ManyToOne({ entity: () => BookTag3, cascade: [Cascade.ALL], nullable: true })
+    bookTag3: BookTag3;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class BookTag3 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property()
+    name: string;
+
+    @Property({ default: \`current_timestamp\` })
+    version: Date;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class Publisher3 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property()
+    name: string;
+
+    @Property()
+    type: string;
+
+}
+",
+  "import { Cascade, Entity, ManyToOne, PrimaryKey } from 'mikro-orm';
+import { Publisher3 } from './Publisher3';
+import { Test3 } from './Test3';
+
+@Entity()
+export class Publisher3ToTest3 {
+
+    @PrimaryKey()
+    id: number;
+
+    @ManyToOne({ entity: () => Publisher3, cascade: [Cascade.ALL], nullable: true })
+    publisher3: Publisher3;
+
+    @ManyToOne({ entity: () => Test3, cascade: [Cascade.ALL], nullable: true })
+    test3: Test3;
+
+}
+",
+  "import { Entity, PrimaryKey, Property } from 'mikro-orm';
+
+@Entity()
+export class Test3 {
+
+    @PrimaryKey()
+    id: number;
+
+    @Property({ nullable: true })
+    name: string;
+
+    @Property()
+    version: number = 1;
+
+}
+",
+]
+`;

--- a/tests/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/tests/__snapshots__/SchemaGenerator.test.ts.snap
@@ -9,7 +9,7 @@ alter table \`author2\` add unique \`author2_email_unique\`(\`email\`);
 alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);
 alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favourite_author_id\`);
 
-create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null, \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned null, \`publisher_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null, \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned null, \`publisher_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
@@ -22,13 +22,13 @@ create table \`test2\` (\`id\` int unsigned not null auto_increment primary key,
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
 alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
 
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8 engine = InnoDB;
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
 create table \`book2_to_book_tag2\` (\`id\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
@@ -42,7 +42,7 @@ alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on delete set null;
-alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on delete set null;
+alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
 
@@ -96,7 +96,7 @@ alter table \`author2\` add unique \`author2_email_unique\`(\`email\`);
 alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\`(\`favourite_book_uuid_pk\`);
 alter table \`author2\` add index \`author2_favourite_author_id_index\`(\`favourite_author_id\`);
 
-create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null, \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned null, \`publisher_id\` int(11) unsigned null) default character set utf8 engine = InnoDB;
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`title\` varchar(255) null, \`perex\` text null, \`price\` float null, \`double\` double null, \`meta\` json null, \`author_id\` int(11) unsigned null, \`publisher_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`book2\` add primary key \`book2_pkey\`(\`uuid_pk\`);
 alter table \`book2\` add index \`book2_author_id_index\`(\`author_id\`);
 alter table \`book2\` add index \`book2_publisher_id_index\`(\`publisher_id\`);
@@ -109,13 +109,13 @@ create table \`test2\` (\`id\` int unsigned not null auto_increment primary key,
 alter table \`test2\` add unique \`test2_book_uuid_pk_unique\`(\`book_uuid_pk\`);
 alter table \`test2\` add index \`test2_book_uuid_pk_index\`(\`book_uuid_pk\`);
 
-create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`baz_id\` int(11) unsigned null, \`foo_bar_id\` int(11) unsigned null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\`(\`baz_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_baz_id_index\`(\`baz_id\`);
 alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\`(\`foo_bar_id\`);
 alter table \`foo_bar2\` add index \`foo_bar2_foo_bar_id_index\`(\`foo_bar_id\`);
 
-create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null) default character set utf8 engine = InnoDB;
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
 create table \`book2_to_book_tag2\` (\`id\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table \`book2_to_book_tag2\` add index \`book2_to_book_tag2_book2_uuid_pk_index\`(\`book2_uuid_pk\`);
@@ -129,7 +129,7 @@ alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\
 alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on update cascade on delete set null;
 
 alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on delete set null;
-alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on delete set null;
+alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
 
 alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
 
@@ -150,34 +150,34 @@ exports[`SchemaGenerator generate schema from metadata [postgres]: postgres-crea
 "set names 'utf8';
 set session_replication_role = 'replica';
 
-create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" datetime(3) not null default current_timestamp(3), \\"updated_at\\" datetime(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int null, \\"terms_accepted\\" boolean not null default 0, \\"identities\\" json null, \\"born\\" datetime null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int null);
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"updated_at\\" timestamp(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null, \\"terms_accepted\\" bool not null default 0, \\"identities\\" json null, \\"born\\" timestamp(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 alter table \\"author2\\" add constraint \\"author2_email_unique\\" unique (\\"email\\");
 
-create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" datetime(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double null, \\"meta\\" json null, \\"author_id\\" int null, \\"publisher_id\\" int null);
+create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double null, \\"meta\\" json null, \\"author_id\\" int4 null, \\"publisher_id\\" int4 not null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
 create table \\"book_tag2\\" (\\"id\\" serial primary key, \\"name\\" varchar(50) not null);
 
 create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" varchar(10) not null);
 
-create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int not null default 1);
+create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int null, \\"foo_bar_id\\" int null, \\"version\\" datetime not null default current_timestamp(3));
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamp(3) not null default current_timestamp(3));
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
-create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null);
+create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"version\\" timestamp(3) not null default current_timestamp(3));
 
-create table \\"book2_to_book_tag2\\" (\\"id\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int not null);
+create table \\"book2_to_book_tag2\\" (\\"id\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int4 not null);
 
-create table \\"publisher2_to_test2\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int not null, \\"test2_id\\" int not null);
+create table \\"publisher2_to_test2\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
 
 alter table \\"author2\\" add constraint \\"author2_favourite_book_uuid_pk_foreign\\" foreign key (\\"favourite_book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete set null;
 alter table \\"author2\\" add constraint \\"author2_favourite_author_id_foreign\\" foreign key (\\"favourite_author_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete set null;
 
 alter table \\"book2\\" add constraint \\"book2_author_id_foreign\\" foreign key (\\"author_id\\") references \\"author2\\" (\\"id\\") on delete set null;
-alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on delete set null;
+alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
 
@@ -226,34 +226,34 @@ drop table if exists \\"foo_baz2\\" cascade;
 drop table if exists \\"book2_to_book_tag2\\" cascade;
 drop table if exists \\"publisher2_to_test2\\" cascade;
 
-create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" datetime(3) not null default current_timestamp(3), \\"updated_at\\" datetime(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int null, \\"terms_accepted\\" boolean not null default 0, \\"identities\\" json null, \\"born\\" datetime null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int null);
+create table \\"author2\\" (\\"id\\" serial primary key, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"updated_at\\" timestamp(3) not null default current_timestamp(3), \\"name\\" varchar(255) not null, \\"email\\" varchar(255) not null, \\"age\\" int4 null, \\"terms_accepted\\" bool not null default 0, \\"identities\\" json null, \\"born\\" timestamp(0) null, \\"favourite_book_uuid_pk\\" varchar(36) null, \\"favourite_author_id\\" int4 null);
 alter table \\"author2\\" add constraint \\"author2_email_unique\\" unique (\\"email\\");
 
-create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" datetime(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double null, \\"meta\\" json null, \\"author_id\\" int null, \\"publisher_id\\" int null);
+create table \\"book2\\" (\\"uuid_pk\\" varchar(36) not null, \\"created_at\\" timestamp(3) not null default current_timestamp(3), \\"title\\" varchar(255) null, \\"perex\\" text null, \\"price\\" float null, \\"double\\" double null, \\"meta\\" json null, \\"author_id\\" int4 null, \\"publisher_id\\" int4 not null);
 alter table \\"book2\\" add constraint \\"book2_pkey\\" primary key (\\"uuid_pk\\");
 
 create table \\"book_tag2\\" (\\"id\\" serial primary key, \\"name\\" varchar(50) not null);
 
 create table \\"publisher2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"type\\" varchar(10) not null);
 
-create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int not null default 1);
+create table \\"test2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) null, \\"book_uuid_pk\\" varchar(36) null, \\"version\\" int4 not null default 1);
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_unique\\" unique (\\"book_uuid_pk\\");
 
-create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int null, \\"foo_bar_id\\" int null, \\"version\\" datetime not null default current_timestamp(3));
+create table \\"foo_bar2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"baz_id\\" int4 null, \\"foo_bar_id\\" int4 null, \\"version\\" timestamp(3) not null default current_timestamp(3));
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_baz_id_unique\\" unique (\\"baz_id\\");
 alter table \\"foo_bar2\\" add constraint \\"foo_bar2_foo_bar_id_unique\\" unique (\\"foo_bar_id\\");
 
-create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null);
+create table \\"foo_baz2\\" (\\"id\\" serial primary key, \\"name\\" varchar(255) not null, \\"version\\" timestamp(3) not null default current_timestamp(3));
 
-create table \\"book2_to_book_tag2\\" (\\"id\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int not null);
+create table \\"book2_to_book_tag2\\" (\\"id\\" serial primary key, \\"book2_uuid_pk\\" varchar(36) not null, \\"book_tag2_id\\" int4 not null);
 
-create table \\"publisher2_to_test2\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int not null, \\"test2_id\\" int not null);
+create table \\"publisher2_to_test2\\" (\\"id\\" serial primary key, \\"publisher2_id\\" int4 not null, \\"test2_id\\" int4 not null);
 
 alter table \\"author2\\" add constraint \\"author2_favourite_book_uuid_pk_foreign\\" foreign key (\\"favourite_book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on update cascade on delete set null;
 alter table \\"author2\\" add constraint \\"author2_favourite_author_id_foreign\\" foreign key (\\"favourite_author_id\\") references \\"author2\\" (\\"id\\") on update cascade on delete set null;
 
 alter table \\"book2\\" add constraint \\"book2_author_id_foreign\\" foreign key (\\"author_id\\") references \\"author2\\" (\\"id\\") on delete set null;
-alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on delete set null;
+alter table \\"book2\\" add constraint \\"book2_publisher_id_foreign\\" foreign key (\\"publisher_id\\") references \\"publisher2\\" (\\"id\\") on update cascade on delete cascade;
 
 alter table \\"test2\\" add constraint \\"test2_book_uuid_pk_foreign\\" foreign key (\\"book_uuid_pk\\") references \\"book2\\" (\\"uuid_pk\\") on delete set null;
 
@@ -273,16 +273,16 @@ set session_replication_role = 'origin';
 exports[`SchemaGenerator generate schema from metadata [sqlite]: sqlite-create-schema-dump 1`] = `
 "pragma foreign_keys = off;
 
-create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` text null, \`updated_at\` text null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` text null);
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` datetime null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
-create table \`book3\` (\`id\` integer not null primary key autoincrement, \`title\` text not null);
+create table \`book3\` (\`id\` integer not null primary key autoincrement, \`title\` varchar not null);
 
-create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`version\` text not null default current_timestamp);
+create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
-create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`type\` text not null);
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`type\` varchar not null);
 
-create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` text null, \`version\` integer not null default 1);
+create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar null, \`version\` integer not null default 1);
 
 create table \`book3_to_book_tag3\` (\`id\` integer not null primary key autoincrement);
 
@@ -336,16 +336,16 @@ drop table if exists \`test3\`;
 drop table if exists \`book3_to_book_tag3\`;
 drop table if exists \`publisher3_to_test3\`;
 
-create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` text null, \`updated_at\` text null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` text null);
+create table \`author3\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` varchar not null, \`email\` varchar not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` varchar null, \`born\` datetime null);
 create unique index \`author3_email_unique\` on \`author3\` (\`email\`);
 
-create table \`book3\` (\`id\` integer not null primary key autoincrement, \`title\` text not null);
+create table \`book3\` (\`id\` integer not null primary key autoincrement, \`title\` varchar not null);
 
-create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`version\` text not null default current_timestamp);
+create table \`book_tag3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`version\` datetime not null default current_timestamp);
 
-create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`type\` text not null);
+create table \`publisher3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar not null, \`type\` varchar not null);
 
-create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` text null, \`version\` integer not null default 1);
+create table \`test3\` (\`id\` integer not null primary key autoincrement, \`name\` varchar null, \`version\` integer not null default 1);
 
 create table \`book3_to_book_tag3\` (\`id\` integer not null primary key autoincrement);
 

--- a/tests/entities-sql/Author2.ts
+++ b/tests/entities-sql/Author2.ts
@@ -33,7 +33,7 @@ export class Author2 extends BaseEntity2 {
   @Property({ nullable: true })
   identities: string[];
 
-  @Property({ nullable: true })
+  @Property({ nullable: true, length: 0 })
   born: Date;
 
   @OneToMany({ entity: () => Book2, mappedBy: 'author', orderBy: { createdAt: QueryOrder.ASC } })

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid';
-import { Collection, Entity, IEntity, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property } from '../../lib';
+import { Cascade, Collection, Entity, IEntity, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property } from '../../lib';
 import { Publisher2 } from './Publisher2';
 import { Author2 } from './Author2';
 import { BookTag2 } from './BookTag2';
@@ -32,7 +32,7 @@ export class Book2 {
   @ManyToOne({ cascade: [] })
   author: Author2;
 
-  @ManyToOne({ cascade: [] })
+  @ManyToOne({ cascade: [Cascade.PERSIST, Cascade.REMOVE] })
   publisher: Publisher2;
 
   @OneToOne({ cascade: [], mappedBy: 'book' })

--- a/tests/entities-sql/FooBar2.ts
+++ b/tests/entities-sql/FooBar2.ts
@@ -17,7 +17,7 @@ export class FooBar2 extends BaseEntity22 {
   @OneToOne({ owner: true })
   fooBar: FooBar2;
 
-  @Property({ version: true })
+  @Property({ version: true, length: 3 })
   version: Date;
 
   static create(name: string) {

--- a/tests/entities-sql/FooBaz2.ts
+++ b/tests/entities-sql/FooBaz2.ts
@@ -13,6 +13,9 @@ export class FooBaz2 {
   @OneToOne({ mappedBy: 'baz' })
   bar: FooBar2;
 
+  @Property({ version: true })
+  version: Date;
+
   constructor(name: string) {
     this.name = name;
   }

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -25,9 +25,11 @@ create table `book_tag2` (`id` int unsigned not null auto_increment primary key,
 
 create table `publisher2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `type` varchar(10) not null) default character set utf8 engine = InnoDB;
 
-create table `test2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) null, `book_uuid_pk` varchar(36) null, `version` int(11) not null default 1) default character set utf8 engine = InnoDB;
+create table `test2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) null, `book_uuid_pk` varchar(36) null, `version` int(11) not null default 1, `foo___bar` int(11) unsigned null, `foo___baz` int(11) unsigned null) default character set utf8 engine = InnoDB;
 alter table `test2` add unique `test2_book_uuid_pk_unique`(`book_uuid_pk`);
 alter table `test2` add index `test2_book_uuid_pk_index`(`book_uuid_pk`);
+alter table `test2` add unique `test2_foo___bar_unique`(`foo___bar`);
+alter table `test2` add index `test2_foo___bar_index`(`foo___bar`);
 
 create table `foo_bar2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `baz_id` int(11) unsigned null, `foo_bar_id` int(11) unsigned null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 alter table `foo_bar2` add unique `foo_bar2_baz_id_unique`(`baz_id`);
@@ -35,7 +37,7 @@ alter table `foo_bar2` add index `foo_bar2_baz_id_index`(`baz_id`);
 alter table `foo_bar2` add unique `foo_bar2_foo_bar_id_unique`(`foo_bar_id`);
 alter table `foo_bar2` add index `foo_bar2_foo_bar_id_index`(`foo_bar_id`);
 
-create table `foo_baz2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null) default character set utf8 engine = InnoDB;
+create table `foo_baz2` (`id` int unsigned not null auto_increment primary key, `name` varchar(255) not null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8 engine = InnoDB;
 
 create table `book2_to_book_tag2` (`id` int unsigned not null auto_increment primary key, `book2_uuid_pk` varchar(36) not null, `book_tag2_id` int(11) unsigned not null) default character set utf8 engine = InnoDB;
 alter table `book2_to_book_tag2` add index `book2_to_book_tag2_book2_uuid_pk_index`(`book2_uuid_pk`);
@@ -49,9 +51,10 @@ alter table `author2` add constraint `author2_favourite_book_uuid_pk_foreign` fo
 alter table `author2` add constraint `author2_favourite_author_id_foreign` foreign key (`favourite_author_id`) references `author2` (`id`) on update cascade on delete set null;
 
 alter table `book2` add constraint `book2_author_id_foreign` foreign key (`author_id`) references `author2` (`id`) on delete set null;
-alter table `book2` add constraint `book2_publisher_id_foreign` foreign key (`publisher_id`) references `publisher2` (`id`) on delete set null;
+alter table `book2` add constraint `book2_publisher_id_foreign` foreign key (`publisher_id`) references `publisher2` (`id`) on update cascade on delete cascade;
 
 alter table `test2` add constraint `test2_book_uuid_pk_foreign` foreign key (`book_uuid_pk`) references `book2` (`uuid_pk`) on delete set null;
+alter table `test2` add constraint `test2_foo___bar_foreign` foreign key (`foo___bar`) references `foo_bar2` (`id`) on update cascade on delete set null;
 
 alter table `foo_bar2` add constraint `foo_bar2_baz_id_foreign` foreign key (`baz_id`) references `foo_baz2` (`id`) on update cascade on delete set null;
 alter table `foo_bar2` add constraint `foo_bar2_foo_bar_id_foreign` foreign key (`foo_bar_id`) references `foo_bar2` (`id`) on update cascade on delete set null;

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -11,34 +11,34 @@ drop table if exists "foo_baz2" cascade;
 drop table if exists "book2_to_book_tag2" cascade;
 drop table if exists "publisher2_to_test2" cascade;
 
-create table "author2" ("id" serial primary key, "created_at" timestamp(3) not null default current_timestamp(3), "updated_at" timestamp(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null, "terms_accepted" boolean not null default false, "identities" json null, "born" timestamp null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int null);
+create table "author2" ("id" serial primary key, "created_at" timestamp(3) not null default current_timestamp(3), "updated_at" timestamp(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int4 null, "terms_accepted" bool not null default false, "identities" json null, "born" timestamp(0) null, "favourite_book_uuid_pk" varchar(36) null, "favourite_author_id" int4 null);
 alter table "author2" add constraint "author2_email_unique" unique ("email");
 
-create table "book2" ("uuid_pk" varchar(36) not null, "created_at" timestamp(3) not null default current_timestamp(3), "title" varchar(255) null, "perex" text null, "price" float null, "double" double precision null, "meta" json null, "author_id" int null, "publisher_id" int null, "foo" varchar(255) null);
+create table "book2" ("uuid_pk" character varying(36) not null, "created_at" timestamp(3) not null default current_timestamp(3), "title" varchar(255) null, "perex" text null, "price" float null, "double" double precision null, "meta" json null, "author_id" int4 null, "publisher_id" int4 null, "foo" varchar(255) null);
 alter table "book2" add constraint "book2_pkey" primary key ("uuid_pk");
 
 create table "book_tag2" ("id" serial primary key, "name" varchar(50) not null);
 
 create table "publisher2" ("id" serial primary key, "name" varchar(255) not null, "type" varchar(10) not null);
 
-create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" varchar(36) null, "version" int not null default 1);
+create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" varchar(36) null, "version" int4 not null default 1);
 alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");
 
-create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "baz_id" int null, "foo_bar_id" int null, "version" timestamp(3) not null default current_timestamp(3));
+create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "baz_id" int4 null, "foo_bar_id" int4 null, "version" timestamp(3) not null default current_timestamp(3));
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");
 alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");
 
-create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null);
+create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "version" timestamp(3) not null default current_timestamp(3));
 
-create table "book2_to_book_tag2" ("id" serial primary key, "book2_uuid_pk" varchar(36) not null, "book_tag2_id" int not null);
+create table "book2_to_book_tag2" ("id" serial primary key, "book2_uuid_pk" varchar(36) not null, "book_tag2_id" int4 not null);
 
-create table "publisher2_to_test2" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);
+create table "publisher2_to_test2" ("id" serial primary key, "publisher2_id" int4 not null, "test2_id" int4 not null);
 
 alter table "author2" add constraint "author2_favourite_book_uuid_pk_foreign" foreign key ("favourite_book_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete set null;
 alter table "author2" add constraint "author2_favourite_author_id_foreign" foreign key ("favourite_author_id") references "author2" ("id") on update cascade on delete set null;
 
 alter table "book2" add constraint "book2_author_id_foreign" foreign key ("author_id") references "author2" ("id") on delete set null;
-alter table "book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "publisher2" ("id") on delete set null;
+alter table "book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "publisher2" ("id") on update cascade on delete cascade;
 
 alter table "test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "book2" ("uuid_pk") on delete set null;
 

--- a/tests/sqlite-schema.sql
+++ b/tests/sqlite-schema.sql
@@ -8,16 +8,16 @@ drop table if exists `test3`;
 drop table if exists `book3_to_book_tag3`;
 drop table if exists `publisher3_to_test3`;
 
-create table `author3` (`id` integer not null primary key autoincrement, `created_at` text null, `updated_at` text null, `name` text not null, `email` text not null, `age` integer null, `terms_accepted` integer not null default 0, `identities` text null, `born` text null);
+create table `author3` (`id` integer not null primary key autoincrement, `created_at` datetime null, `updated_at` datetime null, `name` varchar not null, `email` varchar not null, `age` integer null, `terms_accepted` integer not null default 0, `identities` varchar null, `born` datetime null);
 create unique index `author3_email_unique` on `author3` (`email`);
 
-create table `book3` (`id` integer not null primary key autoincrement, `title` text not null, `foo` text null);
+create table `book3` (`id` integer not null primary key autoincrement, `title` varchar not null, `foo` varchar null);
 
-create table `book_tag3` (`id` integer not null primary key autoincrement, `name` text not null, `version` text not null default current_timestamp);
+create table `book_tag3` (`id` integer not null primary key autoincrement, `name` varchar not null, `version` datetime not null default current_timestamp);
 
-create table `publisher3` (`id` integer not null primary key autoincrement, `name` text not null, `type` text not null);
+create table `publisher3` (`id` integer not null primary key autoincrement, `name` varchar not null, `type` varchar not null);
 
-create table `test3` (`id` integer not null primary key autoincrement, `name` text null, `version` integer not null default 1);
+create table `test3` (`id` integer not null primary key autoincrement, `name` varchar null, `version` integer not null default 1);
 
 create table `book3_to_book_tag3` (`id` integer not null primary key autoincrement);
 


### PR DESCRIPTION
New `EntityGenerator` class is present that allows to reverse engineer current database schema and build entity classes based on it. It supports only basic scalar and M:1 properties currently.

You can get the entities source code as a string, or save entities into files via `generate({ save: true })`.

Closes #78